### PR TITLE
undefined global mark_config

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -48,7 +48,7 @@ M.valid_index = valid_index
 function swap(a_idx, b_idx) 
     local config = harpoon.get_mark_config()
     local tmp = config.marks[a_idx]
-    config.marks[a_idx] = mark_config.marks[b_idx]
+    config.marks[a_idx] = config.marks[b_idx]
     config.marks[b_idx] = tmp
 end
 


### PR DESCRIPTION
I believe it was meant to swap the values in the same config

Someone reported this in discord

```
E5108: Error executing lua /home/peter/.vim/plugged/harpoon/lua/harpoon/mark.lua:51: attempt to index global 'mark_config' (a nil value)
```