### PR TITLE
Set filetype for quick menu

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -42,6 +42,7 @@ M.toggle_quick_menu = function()
     end
 
     vim.api.nvim_buf_set_lines(bufh, 0, #contents, false, contents)
+    vim.api.nvim_buf_set_option(bufh, "filetype", "harpoon")
 end
 
 M.nav_file = function(id)


### PR DESCRIPTION
This adds the harpoon filetype to the quick menu so that mappings can be setup specifically for use in the menu. Runonsentence+300points.