### PR TITLE
Save changes when closing menu

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/lua/harpoon/dev.lua
+++ b/lua/harpoon/dev.lua
@@ -1,0 +1,12 @@
+-- Don't include this file, we should manually include it via
+-- require("harpoon.dev").reload();
+--
+-- A quick mapping can be setup using something like:
+-- :nmap <leader>rr :lua require("harpoon.dev").reload()<CR>
+local M = {}
+
+M.reload = function()
+    require("plenary.reload").reload_module("harpoon");
+end
+
+return M

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -202,6 +202,12 @@ M.to_quickfix_list = function()
     vim.fn.setqflist(qf_list)
 end
 
+M.set_mark_list = function(new_list)
+    local config = harpoon.get_mark_config()
+
+    config.marks = new_list
+end
+
 M.to_quickfix_list()
 
 return M

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -21,8 +21,28 @@ function create_window()
     return win_info
 end
 
+function get_menu_items()
+    local lines = vim.api.nvim_buf_get_lines(bufh, 0, -1, true)
+    local indices = {}
+
+    for idx = 1, #lines do
+        local space_location = string.find(lines[idx], ' ')
+
+        if space_location ~= nil then
+            table.insert(indices, string.sub(lines[idx], space_location + 1))
+        end
+    end
+
+    return indices
+end
+
+local save_changes = function()
+    Marked.set_mark_list(get_menu_items())
+end
+
 M.toggle_quick_menu = function()
     if win_id ~= nil and vim.api.nvim_win_is_valid(win_id) then
+        save_changes()
         vim.api.nvim_win_close(win_id, true)
 
         win_id = nil


### PR DESCRIPTION
This PR adds auto-saving of changes when the quick menu is closed. The implementation is very naive. It accepts any changes, and grabs the text after the first space in each line. No validations included.

I also added a .editorconfig and the dev reloader you helped me with.