### PR TITLE
feat(mark): add status method

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -60,6 +60,15 @@ M.get_index_of = function(item)
     return nil
 end
 
+M.status = function()
+    local idx = M.get_index_of(get_buf_name())
+
+    if M.valid_index(idx) then
+        return "M" .. idx
+    end
+    return ""
+end
+
 M.valid_index = function(idx)
     local config = harpoon.get_mark_config()
     return idx ~= nil and config.marks[idx] ~= nil and config.marks[idx] ~= ""


### PR DESCRIPTION
This method can be used to display current mark status in the statusline.

Add the following in your init.vim:
```
hi User1 ctermfg=green guifg=green

function! HarpoonStatus() abort
    return luaeval("require('harpoon.mark').status()")
endfunction
set statusline+=\ %1*%{HarpoonStatus()}
```

![image](https://user-images.githubusercontent.com/4287319/111502159-e33f4600-8745-11eb-99f7-048baebe70cd.png)

