### PR TITLE
Added nav_next and nav_prev functions

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -203,5 +203,9 @@ end
 
 M.to_quickfix_list()
 
+M.get_current_index = function()
+    return M.get_index_of(vim.fn.bufname(vim.fn.bufnr()))
+end
+
 return M
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -134,5 +134,38 @@ function M.close_notification(bufnr)
     vim.api.nvim_buf_delete(bufnr)
 end
 
+M.nav_next = function()
+    local current_index = Marked.get_current_index()
+    local number_of_items = Marked.get_length()
+
+    if current_index  == nil then
+        current_index = 1
+    else
+        current_index = current_index + 1
+    end
+
+    if (current_index > number_of_items)  then
+        current_index = 1
+    end
+    M.nav_file(current_index)
+end
+
+M.nav_prev = function()
+    local current_index = Marked.get_current_index()
+    local number_of_items = Marked.get_length()
+
+    if current_index  == nil then
+        current_index = number_of_items
+    else
+        current_index = current_index - 1
+    end
+
+    if (current_index < 1)  then
+        current_index = number_of_items
+    end
+
+    M.nav_file(current_index)
+end
+
 return M
 


### PR DESCRIPTION
This allows to cycle through the harpoon marks list
Hi @ThePrimeagen , not sure if this is something you want.

Also I haven't done much lua+neovim plugin stuff, so please give me any feedback, if I'm doing it totally wrong, let me know too :slightly_smiling_face: 

sample key binding:
```
nnoremap <silent> <C-Left> :lua require("harpoon.ui").nav_prev()<CR>
nnoremap <silent> <C-Down> :lua require("harpoon.ui").nav_next()<CR>
```