### PR TITLE
remove print statement to a nonexistent value

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -54,7 +54,7 @@ end
 M.toggle_quick_menu = function()
     if Harpoon_win_id ~= nil and vim.api.nvim_win_is_valid(Harpoon_win_id) then
         local global_config = harpoon.get_global_settings()
-        print(global_config.save_on_menu_quit)
+
         if global_config.save_on_toggle then
             require('harpoon.ui').on_menu_save()
         end


### PR DESCRIPTION
I assume it was used for debugging, but the config value was renamed so it prints `nil` every time the menu is opened.