### PR TITLE
feat(term): add string.format to term cmds

### DIFF
--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -52,7 +52,7 @@ M.gotoTerminal = function(idx)
     vim.api.nvim_set_current_buf(term_handle.buf_id)
 end
 
-M.sendCommand = function(idx, cmd)
+M.sendCommand = function(idx, cmd, ...)
     local term_handle = find_terminal(idx)
 
     if type(cmd) == "number" then
@@ -60,7 +60,7 @@ M.sendCommand = function(idx, cmd)
     end
 
     if cmd then
-        vim.fn.chansend(term_handle.term_id, cmd)
+        vim.fn.chansend(term_handle.term_id, string.format(cmd, ...))
     end
 end
 


### PR DESCRIPTION
I've tested the following:
```
lua << EOF
require("harpoon").setup({
    projects = {
        ["/home/asbjorn/devel/harpoon"] = {
            term = {
                cmds = {
                    "echo %s hello %s\n",
                    "echo this is item 2\n"
                }
            },
        }
    }
})
EOF
```

```
:lua require("harpoon.term").sendCommand(1, 1, "a", vim.fn.expand("%:p"))
:lua require("harpoon.term").sendCommand(1, 2)
```

Result:
```
[I] 21:12 [asbjorn@AH-XPS] /home/asbjorn/devel/harpoon [format_term_cmds] > echo a hello /home/asbjorn/devel/harpoon/README.md
a hello /home/asbjorn/devel/harpoon/README.md
[I] 21:12 [asbjorn@AH-XPS] /home/asbjorn/devel/harpoon [format_term_cmds] > echo this is item 2
this is item 2
```