### PR TITLE
Add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,5 +176,7 @@ require("harpoon").setup({
 
 ```
 
+## Debugging
+Harpoon writes logs to a `harpoon.log` file that resides in Neovim's cache path. (`:echo stdpath("cache")` to find where that is for you.)
 
-
+By default, logging is enabled for warnings and above. This can be changed by setting `vim.g.harpoon_log_level` variable to one of the following log levels: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`. Note that this would have to be done **before** harpoon's `setup` call. Alternatively, it can be more convenient to launch Neovim with an environment variable, e.g. `> HARPOON_LOG=trace nvim`. In case both, `vim.g` and an environment variable are used, the log level set by the environment variable overrules. Supplying an invalid log level defaults back to warnings.

--- a/lua/harpoon/dev.lua
+++ b/lua/harpoon/dev.lua
@@ -11,7 +11,7 @@ end
 
 local function set_log_level()
     local log_levels = { "trace", "debug", "info", "warning", "error", "fatal" }
-    local log_level = vim.g.harpoon_log_level
+    local log_level = vim.g.harpoon_log_level or vim.env.HARPOON_LOG
 
     for _, level in pairs(log_levels) do
         if level == log_level then

--- a/lua/harpoon/dev.lua
+++ b/lua/harpoon/dev.lua
@@ -10,8 +10,8 @@ M.reload = function()
 end
 
 local function set_log_level()
-    local log_levels = { "trace", "debug", "info", "warning", "error", "fatal" }
-    local log_level = vim.g.harpoon_log_level or vim.env.HARPOON_LOG
+    local log_levels = { "trace", "debug", "info", "warn", "error", "fatal" }
+    local log_level = vim.env.HARPOON_LOG or vim.g.harpoon_log_level
 
     for _, level in pairs(log_levels) do
         if level == log_level then

--- a/lua/harpoon/dev.lua
+++ b/lua/harpoon/dev.lua
@@ -6,7 +6,7 @@
 local M = {}
 
 M.reload = function()
-    require("plenary.reload").reload_module("harpoon")
+    require("plenary.reload").reload_module("harpoon");
 end
 
 local function set_log_level()

--- a/lua/harpoon/dev.lua
+++ b/lua/harpoon/dev.lua
@@ -19,7 +19,7 @@ local function set_log_level()
         end
     end
 
-    return "warn" -- default, if user hasn't set
+    return "warn" -- default, if user hasn't set to one from log_levels
 end
 
 M.log = require("plenary.log").new({

--- a/lua/harpoon/dev.lua
+++ b/lua/harpoon/dev.lua
@@ -6,7 +6,25 @@
 local M = {}
 
 M.reload = function()
-    require("plenary.reload").reload_module("harpoon");
+    require("plenary.reload").reload_module("harpoon")
 end
+
+local function set_log_level()
+    local log_levels = { "trace", "debug", "info", "warning", "error", "fatal" }
+    local log_level = vim.g.harpoon_log_level
+
+    for _, level in pairs(log_levels) do
+        if level == log_level then
+            return log_level
+        end
+    end
+
+    return "warn" -- default, if user hasn't set
+end
+
+M.log = require("plenary.log").new({
+    plugin = "harpoon",
+    level = set_log_level(),
+})
 
 return M

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -28,7 +28,6 @@ local M = {}
     ... high level settings
 }
 --]]
-
 HarpoonConfig = HarpoonConfig or {}
 
 -- tbl_deep_extend does not work the way you would think
@@ -48,7 +47,7 @@ end
 
 local function merge_tables(...)
     local out = {}
-    for i = 1, select("#", ...) do
+    for i = 1, select("#",...) do
         merge_table_impl(out, select(i, ...))
     end
     log.trace("_merge_tables(): Output", out)
@@ -62,10 +61,10 @@ local function ensure_correct_config(config)
         log.trace("ensure_correct_config(): No config found for:", vim.loop.cwd())
         projects[vim.loop.cwd()] = {
             mark = {
-                marks = {},
+                marks = {}
             },
             term = {
-                cmds = {},
+                cmds = {}
             },
         }
     end
@@ -86,7 +85,7 @@ local function ensure_correct_config(config)
         local mark = marks[idx]
         if type(mark) == "string" then
             mark = {
-                filename = mark,
+                filename = mark
             }
             marks[idx] = mark
         end
@@ -145,13 +144,17 @@ M.setup = function(config)
         c_config = {}
     end
 
-    local complete_config = merge_tables({
-        projects = {},
-        global_settings = {
-            ["save_on_toggle"] = false,
-            ["save_on_change"] = true,
+    local complete_config =
+        merge_tables({
+            projects = {},
+            global_settings = {
+                ["save_on_toggle"] = false,
+                ["save_on_change"] = true,
+            },
         },
-    }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
+        expand_dir(c_config),
+        expand_dir(u_config),
+        expand_dir(config))
 
     -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
     -- an object for vim.loop.cwd()

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -145,16 +145,14 @@ M.setup = function(config)
     end
 
     local complete_config =
-        merge_tables({
-            projects = {},
-            global_settings = {
+        merge_tables(
+            {projects = {} , global_settings = {
                 ["save_on_toggle"] = false,
                 ["save_on_change"] = true,
-            },
-        },
-        expand_dir(c_config),
-        expand_dir(u_config),
-        expand_dir(config))
+            }},
+            expand_dir(c_config),
+            expand_dir(u_config),
+            expand_dir(config))
 
     -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
     -- an object for vim.loop.cwd()
@@ -193,3 +191,4 @@ end
 M.setup()
 
 return M
+

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -127,12 +127,13 @@ M.setup = function(config)
     end
 
     local ok, u_config = pcall(read_config, user_config)
-    local ok2, c_config = pcall(read_config, cache_config)
 
     if not ok then
         log.debug("setup(): No user config present at", user_config)
         u_config = {}
     end
+
+    local ok2, c_config = pcall(read_config, cache_config)
 
     if not ok2 then
         log.debug("setup(): No cache config present at", cache_config)
@@ -156,22 +157,22 @@ M.setup = function(config)
 end
 
 M.get_global_settings = function()
-    log.trace("get_global_settings()")
+    log.debug("get_global_settings()")
     return HarpoonConfig.global_settings
 end
 
 M.get_term_config = function()
-    log.trace("get_term_config()")
+    log.debug("get_term_config()")
     return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].term
 end
 
 M.get_mark_config = function()
-    -- log.trace("get_mark_config()")
+    log.debug("get_mark_config()")
     return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].mark
 end
 
 M.get_menu_config = function()
-    log.trace("get_menu_config()")
+    log.debug("get_menu_config()")
     return HarpoonConfig.menu or {}
 end
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -55,6 +55,7 @@ local function merge_tables(...)
 end
 
 local function ensure_correct_config(config)
+    log.debug("_ensure_correct_config()")
     local projects = config.projects
     if projects[vim.loop.cwd()] == nil then
         log.trace("ensure_correct_config(): No config found for:", vim.loop.cwd())
@@ -96,6 +97,9 @@ local function ensure_correct_config(config)
 end
 
 local function expand_dir(config)
+    log.debug("_expand_dir()")
+    log.trace("_expand_dir(): Config pre-expansion:", config)
+
     local projects = config.projects or {}
     for k in pairs(projects) do
         local expanded_path = Path.new(k):expand()
@@ -105,6 +109,7 @@ local function expand_dir(config)
         end
     end
 
+    log.trace("_expand_dir(): Config post-expansion:", config)
     return config
 end
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -51,11 +51,12 @@ local function merge_tables(...)
     for i = 1, select("#", ...) do
         merge_table_impl(out, select(i, ...))
     end
+    log.trace("_merge_tables(): Output", out)
     return out
 end
 
 local function ensure_correct_config(config)
-    log.debug("_ensure_correct_config()")
+    log.trace("_ensure_correct_config()")
     local projects = config.projects
     if projects[vim.loop.cwd()] == nil then
         log.trace("ensure_correct_config(): No config found for:", vim.loop.cwd())
@@ -97,7 +98,7 @@ local function ensure_correct_config(config)
 end
 
 local function expand_dir(config)
-    log.debug("_expand_dir()")
+    log.trace("_expand_dir()")
     log.trace("_expand_dir(): Config pre-expansion:", config)
 
     local projects = config.projects or {}
@@ -119,7 +120,7 @@ M.save = function()
 end
 
 local function read_config(local_config)
-    log.debug("_read_config():", local_config)
+    log.trace("_read_config():", local_config)
     return vim.fn.json_decode(Path:new(local_config):read())
 end
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -46,11 +46,11 @@ local function merge_table_impl(t1, t2)
 end
 
 local function merge_tables(...)
+    log.trace("_merge_tables()")
     local out = {}
     for i = 1, select("#",...) do
         merge_table_impl(out, select(i, ...))
     end
-    log.trace("_merge_tables(): Output", out)
     return out
 end
 
@@ -58,7 +58,7 @@ local function ensure_correct_config(config)
     log.trace("_ensure_correct_config()")
     local projects = config.projects
     if projects[vim.loop.cwd()] == nil then
-        log.trace("ensure_correct_config(): No config found for:", vim.loop.cwd())
+        log.debug("ensure_correct_config(): No config found for:", vim.loop.cwd())
         projects[vim.loop.cwd()] = {
             mark = {
                 marks = {}
@@ -71,12 +71,12 @@ local function ensure_correct_config(config)
 
     local proj = projects[vim.loop.cwd()]
     if proj.mark == nil then
-        log.trace("ensure_correct_config(): No marks found for", vim.loop.cwd())
+        log.debug("ensure_correct_config(): No marks found for", vim.loop.cwd())
         proj.mark = {marks = {}}
     end
 
     if proj.term == nil then
-        log.trace("ensure_correct_config(): No terminal commands found for", vim.loop.cwd())
+        log.debug("ensure_correct_config(): No terminal commands found for", vim.loop.cwd())
         proj.term = {cmds = {}}
     end
 
@@ -113,7 +113,7 @@ local function expand_dir(config)
 end
 
 M.save = function()
-    log.debug("save(): Saving cache config to", cache_config)
+    log.trace("save(): Saving cache config to", cache_config)
     Path:new(cache_config):write(vim.fn.json_encode(HarpoonConfig), "w")
 end
 
@@ -124,7 +124,7 @@ end
 
 -- 1. saved.  Where do we save?
 M.setup = function(config)
-    log.debug("setup(): Setting up...")
+    log.trace("setup(): Setting up...")
 
     if not config then
         config = {}
@@ -159,26 +159,26 @@ M.setup = function(config)
     ensure_correct_config(complete_config)
 
     HarpoonConfig = complete_config
-    log.trace("setup(): Complete config", HarpoonConfig)
+    log.debug("setup(): Complete config", HarpoonConfig)
 end
 
 M.get_global_settings = function()
-    log.debug("get_global_settings()")
+    log.trace("get_global_settings()")
     return HarpoonConfig.global_settings
 end
 
 M.get_term_config = function()
-    log.debug("get_term_config()")
+    log.trace("get_term_config()")
     return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].term
 end
 
 M.get_mark_config = function()
-    log.debug("get_mark_config()")
+    log.trace("get_mark_config()")
     return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].mark
 end
 
 M.get_menu_config = function()
-    log.debug("get_menu_config()")
+    log.trace("get_menu_config()")
     return HarpoonConfig.menu or {}
 end
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -98,7 +98,6 @@ local function ensure_correct_config(config)
 end
 
 local function expand_dir(config)
-    log.trace("_expand_dir()")
     log.trace("_expand_dir(): Config pre-expansion:", config)
 
     local projects = config.projects or {}

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -1,7 +1,9 @@
 local Path = require("plenary.path")
+local utils = require("harpoon.utils")
+local log = require("harpoon.dev").log
+
 local config_path = vim.fn.stdpath("config")
 local data_path = vim.fn.stdpath("data")
-local utils = require("harpoon.utils")
 local user_config = string.format("%s/harpoon.json", config_path)
 local cache_config = string.format("%s/harpoon.json", data_path)
 
@@ -26,6 +28,7 @@ local M = {}
     ... high level settings
 }
 --]]
+
 HarpoonConfig = HarpoonConfig or {}
 
 -- tbl_deep_extend does not work the way you would think
@@ -45,7 +48,7 @@ end
 
 local function merge_tables(...)
     local out = {}
-    for i = 1, select("#",...) do
+    for i = 1, select("#", ...) do
         merge_table_impl(out, select(i, ...))
     end
     return out
@@ -54,23 +57,26 @@ end
 local function ensure_correct_config(config)
     local projects = config.projects
     if projects[vim.loop.cwd()] == nil then
+        log.trace("ensure_correct_config(): No config found for:", vim.loop.cwd())
         projects[vim.loop.cwd()] = {
             mark = {
-                marks = {}
+                marks = {},
             },
             term = {
-                cmds = {}
+                cmds = {},
             },
         }
     end
 
     local proj = projects[vim.loop.cwd()]
     if proj.mark == nil then
-        proj.mark = {marks = {}}
+        log.trace("ensure_correct_config(): No marks found for", vim.loop.cwd())
+        proj.mark = { marks = {} }
     end
 
     if proj.term == nil then
-        proj.term = {cmds = {}}
+        log.trace("ensure_correct_config(): No terminal commands found for", vim.loop.cwd())
+        proj.term = { cmds = {} }
     end
 
     local marks = proj.mark.marks
@@ -78,7 +84,7 @@ local function ensure_correct_config(config)
         local mark = marks[idx]
         if type(mark) == "string" then
             mark = {
-                filename = mark
+                filename = mark,
             }
             marks[idx] = mark
         end
@@ -103,15 +109,18 @@ local function expand_dir(config)
 end
 
 M.save = function()
-    Path:new(cache_config):write(vim.fn.json_encode(HarpoonConfig), 'w')
+    log.debug("save(): Saving cache config to", cache_config)
+    Path:new(cache_config):write(vim.fn.json_encode(HarpoonConfig), "w")
 end
 
 local function read_config(local_config)
+    log.debug("_read_config():", local_config)
     return vim.fn.json_decode(Path:new(local_config):read())
 end
 
 -- 1. saved.  Where do we save?
 M.setup = function(config)
+    log.debug("setup(): Setting up...")
 
     if not config then
         config = {}
@@ -121,43 +130,48 @@ M.setup = function(config)
     local ok2, c_config = pcall(read_config, cache_config)
 
     if not ok then
+        log.debug("setup(): No user config present at", user_config)
         u_config = {}
     end
 
     if not ok2 then
+        log.debug("setup(): No cache config present at", cache_config)
         c_config = {}
     end
 
-    local complete_config =
-        merge_tables(
-            {projects = {} , global_settings = {
-                ["save_on_toggle"] = false,
-                ["save_on_change"] = true,
-            }},
-            expand_dir(c_config),
-            expand_dir(u_config),
-            expand_dir(config))
+    local complete_config = merge_tables({
+        projects = {},
+        global_settings = {
+            ["save_on_toggle"] = false,
+            ["save_on_change"] = true,
+        },
+    }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
 
     -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
     -- an object for vim.loop.cwd()
     ensure_correct_config(complete_config)
 
     HarpoonConfig = complete_config
+    log.trace("setup(): Complete config", HarpoonConfig)
 end
 
 M.get_global_settings = function()
+    log.trace("get_global_settings()")
     return HarpoonConfig.global_settings
 end
 
 M.get_term_config = function()
+    log.trace("get_term_config()")
     return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].term
 end
 
 M.get_mark_config = function()
+    -- log.trace("get_mark_config()")
     return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].mark
 end
 
 M.get_menu_config = function()
+    log.trace("get_menu_config()")
     return HarpoonConfig.menu or {}
 end
 
@@ -170,4 +184,3 @@ end
 M.setup()
 
 return M
-

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -72,12 +72,12 @@ local function ensure_correct_config(config)
     local proj = projects[vim.loop.cwd()]
     if proj.mark == nil then
         log.trace("ensure_correct_config(): No marks found for", vim.loop.cwd())
-        proj.mark = { marks = {} }
+        proj.mark = {marks = {}}
     end
 
     if proj.term == nil then
         log.trace("ensure_correct_config(): No terminal commands found for", vim.loop.cwd())
-        proj.term = { cmds = {} }
+        proj.term = {cmds = {}}
     end
 
     local marks = proj.mark.marks

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -70,7 +70,7 @@ end
 
 local function create_mark(filename)
     local cursor_pos = vim.fn.getcurpos()
-    log.debug(string.format(
+    log.trace(string.format(
         "_create_mark(): Creating mark at row: %d, col: %d for %s",
         cursor_pos[2],
         cursor_pos[4],
@@ -87,12 +87,12 @@ local function mark_exists(buf_name)
     log.trace("_mark_exists()")
     for idx = 1, M.get_length() do
         if M.get_marked_file_name(idx) == buf_name then
-            log.trace("_mark_exists(): Mark exists", buf_name)
+            log.debug("_mark_exists(): Mark exists", buf_name)
             return true
         end
     end
 
-    log.trace("_mark_exists(): Mark doesn't exist", buf_name)
+    log.debug("_mark_exists(): Mark doesn't exist", buf_name)
     return false
 end
 
@@ -106,7 +106,7 @@ local function validate_buf_name(buf_name)
 end
 
 M.get_index_of = function(item)
-    log.debug("get_index_of():", item)
+    log.trace("get_index_of():", item)
     if item == nil then
         log.error("get_index_of(): Function has been supplied with a nil value.")
         error("You have provided a nil value to Harpoon, please provide a string rep of the file or the file idx.")
@@ -138,7 +138,7 @@ M.get_index_of = function(item)
 end
 
 M.status = function()
-    log.debug("status()")
+    log.trace("status()")
     local idx = M.get_index_of(get_buf_name())
 
     if M.valid_index(idx) then
@@ -148,7 +148,7 @@ M.status = function()
 end
 
 M.valid_index = function(idx)
-    log.debug("valid_index():", idx)
+    log.trace("valid_index():", idx)
     if idx == nil then
         return false
     end
@@ -159,7 +159,7 @@ end
 
 M.add_file = function(file_name_or_buf_id)
     local buf_name = get_buf_name(file_name_or_buf_id)
-    log.info("add_file():", buf_name)
+    log.trace("add_file():", buf_name)
 
     if M.valid_index(M.get_index_of(buf_name)) then
         -- we don't alter file layout.
@@ -176,7 +176,7 @@ end
 
 -- _emit_on_changed == false should only be used internally
 M.remove_empty_tail = function(_emit_on_changed)
-    log.debug("remove_empty_tail()")
+    log.trace("remove_empty_tail()")
     _emit_on_changed = _emit_on_changed == nil or _emit_on_changed
     local config = harpoon.get_mark_config()
     local found = false
@@ -199,7 +199,7 @@ M.remove_empty_tail = function(_emit_on_changed)
 end
 
 M.store_offset = function()
-    log.debug("store_offset()")
+    log.trace("store_offset()")
     local ok, res = pcall(function()
         local buf_name = get_buf_name()
         local idx = M.get_index_of(buf_name)
@@ -223,6 +223,7 @@ end
 M.rm_file = function(file_name_or_buf_id)
     local buf_name = get_buf_name(file_name_or_buf_id)
     local idx = M.get_index_of(buf_name)
+    log.trace("rm_file(): Removing mark at id", idx)
 
     if not M.valid_index(idx) then
         log.debug("rm_file(): No mark exists for id", file_name_or_buf_id)
@@ -232,18 +233,17 @@ M.rm_file = function(file_name_or_buf_id)
     harpoon.get_mark_config().marks[idx] = create_mark("")
     M.remove_empty_tail(false)
     emit_changed()
-    log.info("rm_file(): Removed mark at id", idx)
 end
 
 M.clear_all = function()
     harpoon.get_mark_config().marks = {}
-    log.info("clear_all(): Clearing all marks.")
+    log.trace("clear_all(): Clearing all marks.")
     emit_changed()
 end
 
 --- ENTERPRISE PROGRAMMING
 M.get_marked_file = function(idxOrName)
-    log.debug("get_marked_file():", idxOrName)
+    log.trace("get_marked_file():", idxOrName)
     if type(idxOrName) == "string" then
         idxOrName = M.get_index_of(idxOrName)
     end
@@ -252,12 +252,12 @@ end
 
 M.get_marked_file_name = function(idx)
     local mark = harpoon.get_mark_config().marks[idx]
-    log.debug("get_marked_file_name():", mark and mark.filename)
+    log.trace("get_marked_file_name():", mark and mark.filename)
     return mark and mark.filename
 end
 
 M.get_length = function()
-    log.debug("get_length()")
+    log.trace("get_length()")
     return table.maxn(harpoon.get_mark_config().marks)
 end
 
@@ -266,7 +266,7 @@ M.set_current_at = function(idx)
     local buf_name = get_buf_name()
     local current_idx = M.get_index_of(buf_name)
 
-    log.info("set_current_at(): Setting id", idx, buf_name)
+    log.trace("set_current_at(): Setting id", idx, buf_name)
 
     -- Remove it if it already exists
     if M.valid_index(current_idx) then
@@ -285,6 +285,7 @@ M.set_current_at = function(idx)
 end
 
 M.to_quickfix_list = function()
+    log.trace("to_quickfix_list(): Sending marks to quickfix list.")
     local config = harpoon.get_mark_config()
     local file_list = filter_empty_string(config.marks)
     local qf_list = {}
@@ -297,13 +298,12 @@ M.to_quickfix_list = function()
             col = mark.col,
         }
     end
-    log.debug("to_quickfix_list(): Sending marks to quickfix list.")
+    log.debug("to_quickfix_list(): qf_list:", qf_list)
     vim.fn.setqflist(qf_list)
 end
 
 M.set_mark_list = function(new_list)
-    log.debug("set_mark_list()")
-    log.trace("set_mark_list(): new_list", new_list)
+    log.trace("set_mark_list(): New list:", new_list)
 
     local config = harpoon.get_mark_config()
 
@@ -324,8 +324,7 @@ end
 
 M.toggle_file = function(file_name_or_buf_id)
     local buf_name = get_buf_name(file_name_or_buf_id)
-
-    log.info("toggle_file():", buf_name)
+    log.trace("toggle_file():", buf_name)
 
     validate_buf_name(buf_name)
 
@@ -341,19 +340,19 @@ M.toggle_file = function(file_name_or_buf_id)
 end
 
 M.get_current_index = function()
-    log.debug("get_current_index()")
+    log.trace("get_current_index()")
     return M.get_index_of(vim.fn.bufname(vim.fn.bufnr()))
 end
 
 M.on = function(event, cb)
-    log.debug("on():", event)
+    log.trace("on():", event)
     if not callbacks[event] then
         log.debug("on(): no callbacks yet for", event)
         callbacks[event] = {}
     end
 
     table.insert(callbacks[event], cb)
-    log.trace("on(): All callbacks:", callbacks)
+    log.debug("on(): All callbacks:", callbacks)
 end
 
 return M

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -10,22 +10,24 @@ local callbacks = {}
 -- I am trying to avoid over engineering the whole thing.  We will likely only
 -- need one event emitted
 local function emit_changed()
+    log.debug("_emit_changed()")
     if harpoon.get_global_settings().save_on_change then
         harpoon.save()
     end
 
     if not callbacks["changed"] then
-        log.debug("emit_changed(): no callbacks for 'changed', returning")
+        log.debug("_emit_changed(): no callbacks for 'changed', returning")
         return
     end
 
     for idx, cb in pairs(callbacks["changed"]) do
-        log.debug(string.format("emit_changed(): Running callback #%d for 'changed'", idx))
+        log.debug(string.format("_emit_changed(): Running callback #%d for 'changed'", idx))
         cb()
     end
 end
 
 local function filter_empty_string(list)
+    log.debug("_filter_empty_string()")
     local next = {}
     for idx = 1, #list do
         if list[idx] ~= "" then
@@ -49,7 +51,7 @@ local function get_first_empty_slot()
 end
 
 local function get_buf_name(id)
-    log.debug("get_buf_name():", id)
+    log.debug("_get_buf_name():", id)
     if id == nil then
         return utils.normalize_path(vim.fn.bufname(vim.fn.bufnr()))
     elseif type(id) == "string" then
@@ -68,6 +70,12 @@ end
 
 local function create_mark(filename)
     local cursor_pos = vim.fn.getcurpos()
+    log.debug(string.format(
+        "_create_mark(): Creating mark at row: %d, col: %d for %s",
+        cursor_pos[2],
+        cursor_pos[4],
+        filename
+    ))
     return {
         filename = filename,
         row = cursor_pos[2],
@@ -89,8 +97,9 @@ local function mark_exists(buf_name)
 end
 
 local function validate_buf_name(buf_name)
+    log.debug("_validate_buf_name():", buf_name)
     if buf_name == "" or buf_name == nil then
-        log.error("validate_buf_name(): Not a valid name for a mark,", buf_name)
+        log.error("_validate_buf_name(): Not a valid name for a mark,", buf_name)
         return
     end
 end
@@ -113,7 +122,7 @@ M.get_index_of = function(item)
         return nil
     end
 
-    -- TODO move this to a "harpoon_" prefix?
+    -- TODO move this to a "harpoon_" prefix or global config?
     if vim.g.manage_a_mark_zero_index then
         item = item + 1
     end
@@ -343,7 +352,7 @@ M.on = function(event, cb)
     end
 
     table.insert(callbacks[event], cb)
-    log.trace(callbacks)
+    log.trace("on(): All callbacks:", callbacks)
 end
 
 return M

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -10,24 +10,24 @@ local callbacks = {}
 -- I am trying to avoid over engineering the whole thing.  We will likely only
 -- need one event emitted
 local function emit_changed()
-    log.debug("_emit_changed()")
+    log.trace("_emit_changed()")
     if harpoon.get_global_settings().save_on_change then
         harpoon.save()
     end
 
     if not callbacks["changed"] then
-        log.debug("_emit_changed(): no callbacks for 'changed', returning")
+        log.trace("_emit_changed(): no callbacks for 'changed', returning")
         return
     end
 
     for idx, cb in pairs(callbacks["changed"]) do
-        log.debug(string.format("_emit_changed(): Running callback #%d for 'changed'", idx))
+        log.trace(string.format("_emit_changed(): Running callback #%d for 'changed'", idx))
         cb()
     end
 end
 
 local function filter_empty_string(list)
-    log.debug("_filter_empty_string()")
+    log.trace("_filter_empty_string()")
     local next = {}
     for idx = 1, #list do
         if list[idx] ~= "" then
@@ -39,7 +39,7 @@ local function filter_empty_string(list)
 end
 
 local function get_first_empty_slot()
-    log.debug("_get_first_empty_slot()")
+    log.trace("_get_first_empty_slot()")
     for idx = 1, M.get_length() do
         local filename = M.get_marked_file_name(idx)
         if filename == "" then
@@ -51,7 +51,7 @@ local function get_first_empty_slot()
 end
 
 local function get_buf_name(id)
-    log.debug("_get_buf_name():", id)
+    log.trace("_get_buf_name():", id)
     if id == nil then
         return utils.normalize_path(vim.fn.bufname(vim.fn.bufnr()))
     elseif type(id) == "string" then
@@ -84,7 +84,7 @@ local function create_mark(filename)
 end
 
 local function mark_exists(buf_name)
-    log.debug("_mark_exists()")
+    log.trace("_mark_exists()")
     for idx = 1, M.get_length() do
         if M.get_marked_file_name(idx) == buf_name then
             log.trace("_mark_exists(): Mark exists", buf_name)
@@ -97,7 +97,7 @@ local function mark_exists(buf_name)
 end
 
 local function validate_buf_name(buf_name)
-    log.debug("_validate_buf_name():", buf_name)
+    log.trace("_validate_buf_name():", buf_name)
     if buf_name == "" or buf_name == nil then
         log.error("_validate_buf_name(): Not a valid name for a mark,", buf_name)
         return
@@ -157,7 +157,7 @@ end
 
 M.add_file = function(file_name_or_buf_id)
     local buf_name = get_buf_name(file_name_or_buf_id)
-    log.debug("add_file():", buf_name)
+    log.info("add_file():", buf_name)
 
     if M.valid_index(M.get_index_of(buf_name)) then
         -- we don't alter file layout.
@@ -231,12 +231,12 @@ M.rm_file = function(file_name_or_buf_id)
     harpoon.get_mark_config().marks[idx] = create_mark("")
     M.remove_empty_tail(false)
     emit_changed()
-    log.debug("rm_file(): Removed mark at id", idx)
+    log.info("rm_file(): Removed mark at id", idx)
 end
 
 M.clear_all = function()
     harpoon.get_mark_config().marks = {}
-    log.debug("clear_all(): Clearing all marks.")
+    log.info("clear_all(): Clearing all marks.")
     emit_changed()
 end
 
@@ -265,7 +265,7 @@ M.set_current_at = function(idx)
     local buf_name = get_buf_name()
     local current_idx = M.get_index_of(buf_name)
 
-    log.debug("set_current_at(): Setting id", idx, buf_name)
+    log.info("set_current_at(): Setting id", idx, buf_name)
 
     -- Remove it if it already exists
     if M.valid_index(current_idx) then
@@ -324,18 +324,18 @@ end
 M.toggle_file = function(file_name_or_buf_id)
     local buf_name = get_buf_name(file_name_or_buf_id)
 
-    log.debug("toggle_file():", buf_name)
+    log.info("toggle_file():", buf_name)
 
     validate_buf_name(buf_name)
 
     if (mark_exists(buf_name)) then
         M.rm_file(buf_name)
         print("Mark removed")
-        log.trace("toggle_file(): Mark removed")
+        log.debug("toggle_file(): Mark removed")
     else
         M.add_file(buf_name)
         print("Mark added")
-        log.trace("toggle_file(): Mark added")
+        log.debug("toggle_file(): Mark added")
     end
 end
 

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -111,10 +111,10 @@ M.get_index_of = function(item)
         return
     end
 
-    if type(item) == "string" then
+    if type(item) == 'string' then
         local relative_item = utils.normalize_path(item)
         for idx = 1, M.get_length() do
-            if M.get_marked_file_name(idx) == relative_item then
+           if M.get_marked_file_name(idx) == relative_item then
                 return idx
             end
         end
@@ -169,7 +169,7 @@ M.add_file = function(file_name_or_buf_id)
     local found_idx = get_first_empty_slot()
     harpoon.get_mark_config().marks[found_idx] = create_mark(buf_name)
     M.remove_empty_tail(false)
-    emit_changed()
+    emit_changed();
 end
 
 -- _emit_on_changed == false should only be used internally
@@ -201,7 +201,6 @@ M.store_offset = function()
     local ok, res = pcall(function()
         local buf_name = get_buf_name()
         local idx = M.get_index_of(buf_name)
-
         if not M.valid_index(idx) then
             return
         end
@@ -356,3 +355,5 @@ M.on = function(event, cb)
 end
 
 return M
+
+

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -100,6 +100,7 @@ local function validate_buf_name(buf_name)
     log.trace("_validate_buf_name():", buf_name)
     if buf_name == "" or buf_name == nil then
         log.error("_validate_buf_name(): Not a valid name for a mark,", buf_name)
+        error("Couldn't find a valid file name to mark, sorry.")
         return
     end
 end
@@ -107,7 +108,8 @@ end
 M.get_index_of = function(item)
     log.debug("get_index_of():", item)
     if item == nil then
-        log.error("get_index_of(): You have provided a nil value to Harpoon, please provide a string rep of the file or the file idx.")
+        log.error("get_index_of(): Function has been supplied with a nil value.")
+        error("You have provided a nil value to Harpoon, please provide a string rep of the file or the file idx.")
         return
     end
 

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -51,14 +51,14 @@ local function find_terminal(idx)
 end
 
 M.gotoTerminal = function(idx)
-    log.info("gotoTerminal(): Terminal:", idx)
+    log.trace("gotoTerminal(): Terminal:", idx)
     local term_handle = find_terminal(idx)
 
     vim.api.nvim_set_current_buf(term_handle.buf_id)
 end
 
 M.sendCommand = function(idx, cmd, ...)
-    log.info("sendCommand(): Terminal:", idx)
+    log.trace("sendCommand(): Terminal:", idx)
     local term_handle = find_terminal(idx)
 
     if type(cmd) == "number" then
@@ -66,7 +66,7 @@ M.sendCommand = function(idx, cmd, ...)
     end
 
     if cmd then
-        log.trace("sendCommand:", cmd)
+        log.debug("sendCommand:", cmd)
         vim.fn.chansend(term_handle.term_id, string.format(cmd, ...))
     end
 end

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -5,7 +5,7 @@ local M = {}
 local terminals = {}
 
 local function create_terminal()
-    log.debug("_create_terminal()")
+    log.trace("_create_terminal()")
     local current_id = vim.fn.bufnr()
 
     vim.cmd(":terminal")
@@ -32,7 +32,7 @@ function getCmd(idx)
 end
 
 local function find_terminal(idx)
-    log.debug("_find_terminal(): Terminal:", idx)
+    log.trace("_find_terminal(): Terminal:", idx)
     local term_handle = terminals[idx]
     if not term_handle or not vim.api.nvim_buf_is_valid(term_handle.buf_id) then
         local buf_id, term_id = create_terminal()
@@ -50,14 +50,14 @@ local function find_terminal(idx)
 end
 
 M.gotoTerminal = function(idx)
-    log.debug("gotoTerminal(): Terminal:", idx)
+    log.info("gotoTerminal(): Terminal:", idx)
     local term_handle = find_terminal(idx)
 
     vim.api.nvim_set_current_buf(term_handle.buf_id)
 end
 
 M.sendCommand = function(idx, cmd, ...)
-    log.debug("sendCommand(): Terminal:", idx)
+    log.info("sendCommand(): Terminal:", idx)
     local term_handle = find_terminal(idx)
 
     if type(cmd) == "number" then

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -1,4 +1,5 @@
-local harpoon = require("harpoon")
+local harpoon = require('harpoon')
+local Path = require("plenary.path")
 local log = require("harpoon.dev").log
 
 local M = {}
@@ -10,7 +11,7 @@ local function create_terminal()
 
     vim.cmd(":terminal")
     local buf_id = vim.fn.bufnr()
-    local term_id = vim.b.terminal_job_id
+    local term_id  = vim.b.terminal_job_id
 
     if term_id == nil then
         log.error("_create_terminal(): term_id is nil")
@@ -20,7 +21,7 @@ local function create_terminal()
 
     -- Make sure the term buffer has "hidden" set so it doesn't get thrown
     -- away and cause an error
-    vim.api.nvim_buf_set_option(buf_id, "bufhidden", "hide")
+    vim.api.nvim_buf_set_option(buf_id, 'bufhidden', 'hide')
 
     -- Resets the buffer back to the old one
     vim.api.nvim_set_current_buf(current_id)
@@ -42,7 +43,7 @@ local function find_terminal(idx)
 
         term_handle = {
             buf_id = buf_id,
-            term_id = term_id,
+            term_id = term_id
         }
         terminals[idx] = term_handle
     end

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -111,14 +111,9 @@ M.nav_file = function(id)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)
-    if set_row and mark.row then
-        local ok, err = pcall(vim.cmd, string.format(":call cursor(%d, %d)", mark.row, mark.col))
-        if not ok then
-            log.warn(
-                string.format("nav_file(): Could not set cursor to row: %d, col: %d", mark.row, mark.col),
-                err
-            )
-        end
+    if set_row and mark.row and mark.col then
+        vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
+        log.trace(string.format("nav_file(): Setting cursor to row: %d, col: %d", mark.row, mark.col))
     end
 end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -1,6 +1,7 @@
-local harpoon = require('harpoon')
-local popup = require('popup')
-local Marked = require('harpoon.mark')
+local harpoon = require("harpoon")
+local popup = require("popup")
+local Marked = require("harpoon.mark")
+local log = require("harpoon.dev").log
 
 local M = {}
 
@@ -97,6 +98,7 @@ end
 M.nav_file = function(id)
     local idx = Marked.get_index_of(id)
     if not Marked.valid_index(idx) then
+        log.debug("nav_file(): No mark exists for id", id)
         return
     end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -169,7 +169,7 @@ function M.close_notification(bufnr)
 end
 
 M.nav_next = function()
-    log.debug("nav_next()")
+    log.info("nav_next()")
     local current_index = Marked.get_current_index()
     local number_of_items = Marked.get_length()
 
@@ -186,7 +186,7 @@ M.nav_next = function()
 end
 
 M.nav_prev = function()
-    log.debug("nav_prev()")
+    log.info("nav_prev()")
     local current_index = Marked.get_current_index()
     local number_of_items = Marked.get_length()
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -41,7 +41,7 @@ local function get_menu_items()
 
     for idx = 1, #lines do
         local space_location = string.find(lines[idx], ' ')
-        log.trace("_get_menu_items():", idx, space_location)
+        log.debug("_get_menu_items():", idx, space_location)
 
         if space_location ~= nil then
             table.insert(indices, string.sub(lines[idx], space_location + 1))
@@ -54,7 +54,7 @@ end
 
 
 M.toggle_quick_menu = function()
-    log.info("toggle_quick_menu()")
+    log.trace("toggle_quick_menu()")
     if Harpoon_win_id ~= nil and vim.api.nvim_win_is_valid(Harpoon_win_id) then
         local global_config = harpoon.get_global_settings()
 
@@ -94,12 +94,12 @@ M.toggle_quick_menu = function()
 end
 
 M.on_menu_save = function()
-    log.debug("on_menu_save()")
+    log.trace("on_menu_save()")
     Marked.set_mark_list(get_menu_items())
 end
 
 M.nav_file = function(id)
-    log.info("nav_file(): Navigating to", id)
+    log.trace("nav_file(): Navigating to", id)
     local idx = Marked.get_index_of(id)
     if not Marked.valid_index(idx) then
         log.debug("nav_file(): No mark exists for id", id)
@@ -113,7 +113,7 @@ M.nav_file = function(id)
     vim.api.nvim_set_current_buf(buf_id)
     if set_row and mark.row and mark.col then
         vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
-        log.trace(string.format("nav_file(): Setting cursor to row: %d, col: %d", mark.row, mark.col))
+        log.debug(string.format("nav_file(): Setting cursor to row: %d, col: %d", mark.row, mark.col))
     end
 end
 
@@ -164,7 +164,7 @@ function M.close_notification(bufnr)
 end
 
 M.nav_next = function()
-    log.info("nav_next()")
+    log.trace("nav_next()")
     local current_index = Marked.get_current_index()
     local number_of_items = Marked.get_length()
 
@@ -181,7 +181,7 @@ M.nav_next = function()
 end
 
 M.nav_prev = function()
-    log.info("nav_prev()")
+    log.trace("nav_prev()")
     local current_index = Marked.get_current_index()
     local number_of_items = Marked.get_length()
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -1,6 +1,6 @@
-local harpoon = require("harpoon")
-local popup = require("popup")
-local Marked = require("harpoon.mark")
+local harpoon = require('harpoon')
+local popup = require('popup')
+local Marked = require('harpoon.mark')
 local log = require("harpoon.dev").log
 
 local M = {}
@@ -13,12 +13,12 @@ local function create_window()
     local config = harpoon.get_menu_config()
     local width = config.width or 60
     local height = config.height or 10
-    local borderchars = config.borderchars or { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
+    local borderchars = config.borderchars or { '─', '│', '─', '│', '╭', '╮', '╯', '╰' }
     local bufnr = vim.api.nvim_create_buf(false, false)
 
     local Harpoon_win_id, win = popup.create(bufnr, {
-        title = "Harpoon",
-        highlight = "HarpoonWindow",
+        title = 'Harpoon',
+        highlight = 'HarpoonWindow',
         line = math.floor(((vim.o.lines - height) / 2) - 1),
         col = math.floor((vim.o.columns - width) / 2),
         minwidth = width,
@@ -26,7 +26,7 @@ local function create_window()
         borderchars = borderchars,
     })
 
-    vim.api.nvim_win_set_option(win.border.win_id, "winhl", "Normal:HarpoonBorder")
+    vim.api.nvim_win_set_option(win.border.win_id, 'winhl', 'Normal:HarpoonBorder')
 
     return {
         bufnr = bufnr,
@@ -40,7 +40,7 @@ local function get_menu_items()
     local indices = {}
 
     for idx = 1, #lines do
-        local space_location = string.find(lines[idx], " ")
+        local space_location = string.find(lines[idx], ' ')
         log.trace("_get_menu_items():", idx, space_location)
 
         if space_location ~= nil then
@@ -51,13 +51,15 @@ local function get_menu_items()
     return indices
 end
 
+
+
 M.toggle_quick_menu = function()
     log.info("toggle_quick_menu()")
     if Harpoon_win_id ~= nil and vim.api.nvim_win_is_valid(Harpoon_win_id) then
         local global_config = harpoon.get_global_settings()
 
         if global_config.save_on_toggle then
-            require("harpoon.ui").on_menu_save()
+            require('harpoon.ui').on_menu_save()
         end
 
         vim.api.nvim_win_close(Harpoon_win_id, true)
@@ -122,14 +124,14 @@ end
 
 function M.location_window(options)
     local default_options = {
-        relative = "editor",
-        style = "minimal",
+        relative = 'editor',
+        style = 'minimal',
         width = 30,
         height = 15,
         row = 2,
         col = 2,
     }
-    options = vim.tbl_extend("keep", options, default_options)
+    options = vim.tbl_extend('keep', options, default_options)
 
     local bufnr = options.bufnr or vim.fn.nvim_create_buf(false, true)
     local win_id = vim.fn.nvim_open_win(bufnr, true, options)
@@ -150,15 +152,15 @@ function M.notification(text)
         width = 20,
         height = 2,
         row = 1,
-        col = win_width - 21,
+        col = win_width - 21
     })
 
-    vim.api.nvim_buf_set_lines(info.bufnr, 0, 5, false, { "!!! Notification", text })
+    vim.api.nvim_buf_set_lines(info.bufnr, 0, 5, false, {"!!! Notification", text})
     vim.api.nvim_set_current_win(prev_win)
 
     return {
         bufnr = info.bufnr,
-        win_id = info.win_id,
+        win_id = info.win_id
     }
 end
 
@@ -171,13 +173,13 @@ M.nav_next = function()
     local current_index = Marked.get_current_index()
     local number_of_items = Marked.get_length()
 
-    if current_index == nil then
+    if current_index  == nil then
         current_index = 1
     else
         current_index = current_index + 1
     end
 
-    if (current_index > number_of_items) then
+    if (current_index > number_of_items)  then
         current_index = 1
     end
     M.nav_file(current_index)
@@ -188,13 +190,13 @@ M.nav_prev = function()
     local current_index = Marked.get_current_index()
     local number_of_items = Marked.get_length()
 
-    if current_index == nil then
+    if current_index  == nil then
         current_index = number_of_items
     else
         current_index = current_index - 1
     end
 
-    if (current_index < 1) then
+    if (current_index < 1)  then
         current_index = number_of_items
     end
 
@@ -202,3 +204,4 @@ M.nav_prev = function()
 end
 
 return M
+

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -35,11 +35,13 @@ local function create_window()
 end
 
 local function get_menu_items()
+    log.debug("_get_menu_items()")
     local lines = vim.api.nvim_buf_get_lines(Harpoon_bufh, 0, -1, true)
     local indices = {}
 
     for idx = 1, #lines do
         local space_location = string.find(lines[idx], " ")
+        log.trace("_get_menu_items():", idx, space_location)
 
         if space_location ~= nil then
             table.insert(indices, string.sub(lines[idx], space_location + 1))

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -9,7 +9,7 @@ Harpoon_win_id = nil
 Harpoon_bufh = nil
 
 local function create_window()
-    log.debug("_create_window()")
+    log.trace("_create_window()")
     local config = harpoon.get_menu_config()
     local width = config.width or 60
     local height = config.height or 10
@@ -35,7 +35,7 @@ local function create_window()
 end
 
 local function get_menu_items()
-    log.debug("_get_menu_items()")
+    log.trace("_get_menu_items()")
     local lines = vim.api.nvim_buf_get_lines(Harpoon_bufh, 0, -1, true)
     local indices = {}
 
@@ -52,7 +52,7 @@ local function get_menu_items()
 end
 
 M.toggle_quick_menu = function()
-    log.debug("toggle_quick_menu()")
+    log.info("toggle_quick_menu()")
     if Harpoon_win_id ~= nil and vim.api.nvim_win_is_valid(Harpoon_win_id) then
         local global_config = harpoon.get_global_settings()
 
@@ -97,7 +97,7 @@ M.on_menu_save = function()
 end
 
 M.nav_file = function(id)
-    log.debug("nav_file(): Navigating to", id)
+    log.info("nav_file(): Navigating to", id)
     local idx = Marked.get_index_of(id)
     if not Marked.valid_index(idx) then
         log.debug("nav_file(): No mark exists for id", id)


### PR DESCRIPTION
Here's my take on logging for #8. It uses the convenient `plenary.log` which writes a `harpoon.log` to `vim.fn.stdpath("cache")`.

By default the logging is enabled for `warning` and above. It can be changed with an env variable, e.g. when launching nvim `$ HARPOON_LOG=trace nvim` or setting `vim.g.harpoon_log_level` before requiring harpoon. I was considering harpoon's `global_setting` instead of the `vim.g`, but you'll get a recursive require if you want to log in `init.lua` then. Maybe there's some clever trick to get around this.

`warn` and `error` were assigned according to the existing print and error statements. Functions that users would directly interact with are `info`s, even just so that finding them in the logs is easier. Most other are `debug`. Local functions are assigned `trace` along with some more verbose stuff such as parts of the config at different stages.

I have already used the logs to debug the harpoon marker for my statusline. While doing that I discovered that the callbacks for the "changed" event weren’t actually called, since the callbacks table is nested, so it was iterating the keys not the callbacks under the keys. I've fixed that here, but if necessary I can submit it as a separate PR.

Over time it needs to be adjusted. I have used it only very briefly now, so I can't really tell what feels out of place. With use we know where we wish it was more verbose and what just creates noise.

---

The readme has been updated now to document logging and I've reverted the nonfunctional changes made by my formatter, although we should consider having a formatter.
