### PR TITLE
feat(ui): navigate to mark on enter

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -87,8 +87,14 @@ M.toggle_quick_menu = function()
     vim.api.nvim_buf_set_option(Harpoon_bufh, "filetype", "harpoon")
     vim.api.nvim_buf_set_option(Harpoon_bufh, "buftype", "acwrite")
     vim.api.nvim_buf_set_option(Harpoon_bufh, "bufhidden", "delete")
+    vim.api.nvim_buf_set_keymap(Harpoon_bufh, "n", "<CR>", ":lua require('harpoon.ui').on_norm_enter()<CR>", {})
     vim.cmd(string.format("autocmd BufWriteCmd <buffer=%s> :lua require('harpoon.ui').on_menu_save()", Harpoon_bufh))
     vim.cmd(string.format("autocmd BufModifiedSet <buffer=%s> set nomodified", Harpoon_bufh))
+end
+
+M.on_norm_enter = function()
+    local idx = vim.fn.line('.')
+    M.nav_file(idx)
 end
 
 M.on_menu_save = function()


### PR DESCRIPTION
It has it's limitations and can be improved.
Should we split the line `lua print(vim.fn.getline('.'))` on space and get the index?
Should we split the line and navigate with the path?

The path is safer if you haven't saved before hitting enter. Thoughts @ThePrimeagen ?

I quickly made this to better my workflow, but can adjust after settling the questions above.

The reasoning behind this is that I might have more marks than 4 marks, and I don't want to delete any.
Workspaces may solve the need for this, but I like that I can navigate with `enter` from normal mode.