### PR TITLE
GH actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Format
+
+on: [push, pull_request]
+
+jobs:
+    format:
+        name: Stylua
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: date +%W > weekly
+
+            - name: Restore cache
+              id: cache
+              uses: actions/cache@v2
+              with:
+                path: |
+                  ~/.cargo/bin
+                key: ${{ runner.os }}-cargo-${{ hashFiles('weekly') }}
+
+            - name: Install
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: cargo install stylua
+
+            - name: Format
+              run: stylua --check lua/ --config-path=.stylua.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+    lint:
+        name: Luacheck
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install luarocks
+                  sudo luarocks install luacheck
+
+            - name: Lint
+              run: luacheck lua/harpoon

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,10 @@
+std = luajit
+cache = true
+codes = true
+
+globals = {
+    "HarpoonConfig",
+    "Harpoon_bufh",
+    "Harpoon_win_id",
+}
+read_globals = { "vim" }

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -1,5 +1,4 @@
 local harpoon = require("harpoon")
-local Path = require("plenary.path")
 local log = require("harpoon.dev").log
 
 local M = {}
@@ -28,8 +27,20 @@ local function create_terminal()
     return buf_id, term_id
 end
 
-function getCmd(idx)
-    return
+M.getCmd = function(idx)
+    log.trace("getCmd()")
+    local cmd
+    if type(idx) == "number" then
+        cmd = harpoon.get_term_config().cmds[idx]
+    else
+        log.error("getCmd(): Index is expected to be a number.")
+    end
+
+    if cmd then
+        return cmd
+    else
+        error("Command does not exist for that id.")
+    end
 end
 
 local function find_terminal(idx)

--- a/lua/harpoon/test/manage-a-mark.lua
+++ b/lua/harpoon/test/manage-a-mark.lua
@@ -1,5 +1,3 @@
 -- TODO: Harpooned
-local Marker = require('harpoon.mark')
-local eq = assert.are.same
-
-
+-- local Marker = require('harpoon.mark')
+-- local eq = assert.are.same


### PR DESCRIPTION
Tests are under a different issue (#30), so this one just deals with some ci action. closes #9

- add an action for
  - linting with [luacheck](https://github.com/luarocks/luacheck)
  - formatting check with previously added stylua
- commented out the test file stub, for now, to make the linter happy
- fleshed out getCmd function. wasn't sure what it's purpose was, but i didn't want to get rid of it

I also considered swapping out stylua for [luaFormatter](https://github.com/Koihik/LuaFormatter), to have both tools be luarocks based, but luaformatter creates some really funky looking code - it tries to inline too much or alternatively breaks everything onto a new line.

I also looked into [selene](https://github.com/Kampfkarren/selene) which, like stylua, is rust based, instead of using luacheck. It seemed like it wanted me to add types for all globals and everything we access. The documentation was lacking so I wasn't sure if there's a way around it. Anyway, Telescope uses luacheck so I feel it will also work for us.

Formatter action uses a cache that is valid for a week, since stylua is updated about once a week. Installing and building it each time takes about ~3 minutes, with cache both actions should be around 20-30 seconds.
