### PR TITLE
fix(ui): Sets buffer as 'listed' when navigating

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -139,6 +139,7 @@ M.nav_file = function(id)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)
+    vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
     if set_row and mark.row and mark.col then
         vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
         log.debug(string.format(


### PR DESCRIPTION
According to the documentation for `vim.fn.bufnr` (`:h bufnr`), the
created buffer will have the option 'unlisted' by default.

This means that when navigating to a file, if that file wasn't
previously open, the new buffer won't appear in buffers list.

This fix set the buffer to be 'listed' when navigating.