### PR TITLE
prevent indexing nil vals in ensure_correct_config

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -88,8 +88,8 @@ local function ensure_correct_config(config)
     end
 
     local marks = proj.mark.marks
-    for idx = 1, #marks do
-        local mark = marks[idx]
+
+    for idx, mark in pairs(marks) do
         if type(mark) == "string" then
             mark = {
                 filename = mark,

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -264,10 +264,8 @@ M.get_marked_file_name = function(idx)
 end
 
 M.get_length = function()
-    log.trace("M.get_length()")
-    local length = table.maxn(harpoon.get_mark_config().marks)
-    log.debug("M.get_length():", length)
-    return length
+    log.trace("get_length()")
+    return table.maxn(harpoon.get_mark_config().marks)
 end
 
 M.set_current_at = function(idx)

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -264,16 +264,17 @@ M.get_marked_file_name = function(idx)
 end
 
 M.get_length = function()
-    log.trace("get_length()")
-    return table.maxn(harpoon.get_mark_config().marks)
+    log.trace("M.get_length()")
+    local length = table.maxn(harpoon.get_mark_config().marks)
+    log.debug("M.get_length():", length)
+    return length
 end
 
 M.set_current_at = function(idx)
-    local config = harpoon.get_mark_config()
     local buf_name = get_buf_name()
-    local current_idx = M.get_index_of(buf_name)
-
     log.trace("set_current_at(): Setting id", idx, buf_name)
+    local config = harpoon.get_mark_config()
+    local current_idx = M.get_index_of(buf_name)
 
     -- Remove it if it already exists
     if M.valid_index(current_idx) then


### PR DESCRIPTION
setting a mark non-consecutively may result in `ensure_correct_config` trying to access nil values. `set_current_at` does fix the empty slots eventually, but before it does so, it calls `get_length` which calls `ensure_correct_config`.

It happens only sometimes due to how lua does memory allocation for arrays. Getting the length with `#` may or may not return the last index, depending on where the previous values are located.

---

Other:

some changes to log orders