### PR TITLE
Add requirements missing in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ to go to the files you want.
 Unlimited terminals and navigation.
 
 ## Installation
-Simply install via your favorite plugin manager.
+Simply install via your favorite plugin manager. (Requires NeoVim >= 0.5.0)
 
 ```vim
 Plug 'nvim-lua/plenary.nvim' " don't forget to add this one if you don't have it yet!
+Plug 'nvim-lua/popup.nvim'
 Plug 'ThePrimeagen/harpoon'
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ to go to the files you want.
 Unlimited terminals and navigation.
 
 ## Installation
-Simply install via your favorite plugin manager. (Requires NeoVim >= 0.5.0)
+### Requires Neovim version 0.5.0+
+Simply install via your favorite plugin manager.
 
 ```vim
 Plug 'nvim-lua/plenary.nvim' " don't forget to add this one if you don't have it yet!


### PR DESCRIPTION
Took me a while to figure out that it wouldn't work on nvim 0.4. Also, popup.nvim is required.