### PR TITLE
custom terminal creation command

### DIFF
--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -4,14 +4,14 @@ local log = require("harpoon.dev").log
 local M = {}
 local terminals = {}
 
-local function create_terminal(create_cmd)
-    if not create_cmd then
-        create_cmd = ":terminal"
+local function create_terminal(create_with)
+    if not create_with then
+        create_with = ":terminal"
     end
-    log.trace("_create_terminal(): Init:", create_cmd)
+    log.trace("_create_terminal(): Init:", create_with)
     local current_id = vim.fn.bufnr()
 
-    vim.cmd(create_cmd)
+    vim.cmd(create_with)
     local buf_id = vim.fn.bufnr()
     local term_id = vim.b.terminal_job_id
 
@@ -30,11 +30,14 @@ local function create_terminal(create_cmd)
     return buf_id, term_id
 end
 
-local function find_terminal(idx, create_cmd)
-    log.trace("_find_terminal(): Terminal:", idx)
-    local term_handle = terminals[idx]
+local function find_terminal(args)
+    log.trace("_find_terminal(): Terminal:", args)
+    if type(args) == "number" then
+        args = { idx=args }
+    end
+    local term_handle = terminals[args.idx]
     if not term_handle or not vim.api.nvim_buf_is_valid(term_handle.buf_id) then
-        local buf_id, term_id = create_terminal(create_cmd)
+        local buf_id, term_id = create_terminal(args.create_with)
         if buf_id == nil then
             return
         end
@@ -43,32 +46,29 @@ local function find_terminal(idx, create_cmd)
             buf_id = buf_id,
             term_id = term_id,
         }
-        terminals[idx] = term_handle
+        terminals[args.idx] = term_handle
     end
     return term_handle
 end
 
-M.gotoTerminal = function(idx, create_cmd)
+M.gotoTerminal = function(idx)
     log.trace("gotoTerminal(): Terminal:", idx)
-    local term_handle = find_terminal(idx, create_cmd)
+    local term_handle = find_terminal(idx)
 
     vim.api.nvim_set_current_buf(term_handle.buf_id)
 end
 
-M.sendCommand = function(idx, cmd, create_cmd)
+M.sendCommand = function(idx, cmd, ...)
     log.trace("sendCommand(): Terminal:", idx)
-    local term_handle = find_terminal(idx, create_cmd)
+    local term_handle = find_terminal(idx)
 
     if type(cmd) == "number" then
         cmd = harpoon.get_term_config().cmds[cmd]
     end
-    if type(cmd) == "string" then
-        cmd = {cmd}
-    end
 
     if cmd then
-        log.debug("sendCommand:", cmd[1])
-        vim.fn.chansend(term_handle.term_id, string.format(unpack(cmd)))
+        log.debug("sendCommand:", cmd)
+        vim.fn.chansend(term_handle.term_id, string.format(cmd, ...))
     end
 end
 

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -33,7 +33,7 @@ end
 local function find_terminal(args)
     log.trace("_find_terminal(): Terminal:", args)
     if type(args) == "number" then
-        args = { idx=args }
+        args = { idx = args }
     end
     local term_handle = terminals[args.idx]
     if not term_handle or not vim.api.nvim_buf_is_valid(term_handle.buf_id) then


### PR DESCRIPTION
Adding the possibility for terminal handle to be something else than just pure shell.

For example `.gotoTerminal(2, ':e term://ipython')` and `.sendCommand(2, 'print(123)', ':e term://ipython')` ensures that the terminal one jumps to and send commands to, is an Ipython REPL.