### PR TITLE
moving from vim.fn to vim.api where possible

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -157,7 +157,13 @@ M.setup = function(config)
             ["save_on_toggle"] = false,
             ["save_on_change"] = true,
         },
-    }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
+    }, expand_dir(
+        c_config
+    ), expand_dir(
+        u_config
+    ), expand_dir(
+        config
+    ))
 
     -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
     -- an object for vim.loop.cwd()

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -56,7 +56,7 @@ end
 local function get_buf_name(id)
     log.trace("_get_buf_name():", id)
     if id == nil then
-        return utils.normalize_path(vim.fn.bufname())
+        return utils.normalize_path(vim.api.nvim_buf_get_name(0))
     elseif type(id) == "string" then
         return utils.normalize_path(id)
     end
@@ -72,17 +72,17 @@ local function get_buf_name(id)
 end
 
 local function create_mark(filename)
-    local cursor_pos = vim.fn.getcurpos()
+    local cursor_pos = vim.api.nvim_win_get_cursor(0)
     log.trace(string.format(
         "_create_mark(): Creating mark at row: %d, col: %d for %s",
+        cursor_pos[1],
         cursor_pos[2],
-        cursor_pos[4],
         filename
     ))
     return {
         filename = filename,
-        row = cursor_pos[2],
-        col = cursor_pos[3],
+        row = cursor_pos[1],
+        col = cursor_pos[2],
     }
 end
 
@@ -144,9 +144,9 @@ M.status = function(bufnr)
     log.trace("status()")
     local buf_name
     if bufnr then
-        buf_name = vim.fn.bufname(bufnr)
+        buf_name = vim.api.nvim_buf_get_name(bufnr)
     else
-        buf_name = vim.fn.bufname()
+        buf_name = vim.api.nvim_buf_get_name(0)
     end
 
     local norm_name = utils.normalize_path(buf_name)
@@ -218,14 +218,14 @@ M.store_offset = function()
             return
         end
 
-        local cursor_pos = vim.fn.getcurpos()
+        local cursor_pos = vim.api.nvim_win_get_cursor(0)
         log.debug(string.format(
             "store_offset(): Stored row: %d, col: %d",
-            cursor_pos[2],
-            cursor_pos[3]
+            cursor_pos[1],
+            cursor_pos[2]
         ))
-        harpoon.get_mark_config().marks[idx].row = cursor_pos[2]
-        harpoon.get_mark_config().marks[idx].col = cursor_pos[3]
+        harpoon.get_mark_config().marks[idx].row = cursor_pos[1]
+        harpoon.get_mark_config().marks[idx].col = cursor_pos[2]
     end)
 
     if not ok then
@@ -313,7 +313,8 @@ M.to_quickfix_list = function()
         }
     end
     log.debug("to_quickfix_list(): qf_list:", qf_list)
-    vim.fn.setqflist(qf_list)
+    -- Does this only work when there is an LSP attached to the buffer?
+    vim.lsp.util.set_qflist(qf_list)
 end
 
 M.set_mark_list = function(new_list)
@@ -355,7 +356,7 @@ end
 
 M.get_current_index = function()
     log.trace("get_current_index()")
-    return M.get_index_of(vim.fn.bufname())
+    return M.get_index_of(vim.api.nvim_buf_get_name(0))
 end
 
 M.on = function(event, cb)

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -313,8 +313,7 @@ M.to_quickfix_list = function()
         }
     end
     log.debug("to_quickfix_list(): qf_list:", qf_list)
-    -- Does this only work when there is an LSP attached to the buffer?
-    vim.lsp.util.set_qflist(qf_list)
+    vim.fn.setqflist(qf_list)
 end
 
 M.set_mark_list = function(new_list)

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -21,10 +21,12 @@ local function emit_changed()
     end
 
     for idx, cb in pairs(callbacks["changed"]) do
-        log.trace(string.format(
-            "_emit_changed(): Running callback #%d for 'changed'",
-            idx
-        ))
+        log.trace(
+            string.format(
+                "_emit_changed(): Running callback #%d for 'changed'",
+                idx
+            )
+        )
         cb()
     end
 end
@@ -73,12 +75,14 @@ end
 
 local function create_mark(filename)
     local cursor_pos = vim.api.nvim_win_get_cursor(0)
-    log.trace(string.format(
-        "_create_mark(): Creating mark at row: %d, col: %d for %s",
-        cursor_pos[1],
-        cursor_pos[2],
-        filename
-    ))
+    log.trace(
+        string.format(
+            "_create_mark(): Creating mark at row: %d, col: %d for %s",
+            cursor_pos[1],
+            cursor_pos[2],
+            filename
+        )
+    )
     return {
         filename = filename,
         row = cursor_pos[1],
@@ -102,7 +106,10 @@ end
 local function validate_buf_name(buf_name)
     log.trace("_validate_buf_name():", buf_name)
     if buf_name == "" or buf_name == nil then
-        log.error("_validate_buf_name(): Not a valid name for a mark,", buf_name)
+        log.error(
+            "_validate_buf_name(): Not a valid name for a mark,",
+            buf_name
+        )
         error("Couldn't find a valid file name to mark, sorry.")
         return
     end
@@ -111,8 +118,12 @@ end
 M.get_index_of = function(item)
     log.trace("get_index_of():", item)
     if item == nil then
-        log.error("get_index_of(): Function has been supplied with a nil value.")
-        error("You have provided a nil value to Harpoon, please provide a string rep of the file or the file idx.")
+        log.error(
+            "get_index_of(): Function has been supplied with a nil value."
+        )
+        error(
+            "You have provided a nil value to Harpoon, please provide a string rep of the file or the file idx."
+        )
         return
     end
 
@@ -219,11 +230,13 @@ M.store_offset = function()
         end
 
         local cursor_pos = vim.api.nvim_win_get_cursor(0)
-        log.debug(string.format(
-            "store_offset(): Stored row: %d, col: %d",
-            cursor_pos[1],
-            cursor_pos[2]
-        ))
+        log.debug(
+            string.format(
+                "store_offset(): Stored row: %d, col: %d",
+                cursor_pos[1],
+                cursor_pos[2]
+            )
+        )
         harpoon.get_mark_config().marks[idx].row = cursor_pos[1]
         harpoon.get_mark_config().marks[idx].col = cursor_pos[2]
     end)

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -9,10 +9,10 @@ local function create_terminal(create_with)
         create_with = ":terminal"
     end
     log.trace("_create_terminal(): Init:", create_with)
-    local current_id = vim.fn.bufnr()
+    local current_id = vim.api.nvim_get_current_buf()
 
     vim.cmd(create_with)
-    local buf_id = vim.fn.bufnr()
+    local buf_id = vim.api.nvim_get_current_buf()
     local term_id = vim.b.terminal_job_id
 
     if term_id == nil then
@@ -68,7 +68,7 @@ M.sendCommand = function(idx, cmd, ...)
 
     if cmd then
         log.debug("sendCommand:", cmd)
-        vim.fn.chansend(term_handle.term_id, string.format(cmd, ...))
+        vim.api.nvim_chan_send(term_handle.term_id, string.format(cmd, ...))
     end
 end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -105,14 +105,18 @@ M.toggle_quick_menu = function()
         ":lua require('harpoon.ui').select_menu_item()<CR>",
         {}
     )
-    vim.cmd(string.format(
-        "autocmd BufWriteCmd <buffer=%s> :lua require('harpoon.ui').on_menu_save()",
-        Harpoon_bufh
-    ))
-    vim.cmd(string.format(
-        "autocmd BufModifiedSet <buffer=%s> set nomodified",
-        Harpoon_bufh
-    ))
+    vim.cmd(
+        string.format(
+            "autocmd BufWriteCmd <buffer=%s> :lua require('harpoon.ui').on_menu_save()",
+            Harpoon_bufh
+        )
+    )
+    vim.cmd(
+        string.format(
+            "autocmd BufModifiedSet <buffer=%s> set nomodified",
+            Harpoon_bufh
+        )
+    )
 end
 
 M.select_menu_item = function()
@@ -142,11 +146,13 @@ M.nav_file = function(id)
     vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
     if set_row and mark.row and mark.col then
         vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
-        log.debug(string.format(
-            "nav_file(): Setting cursor to row: %d, col: %d",
-            mark.row,
-            mark.col
-        ))
+        log.debug(
+            string.format(
+                "nav_file(): Setting cursor to row: %d, col: %d",
+                mark.row,
+                mark.col
+            )
+        )
     end
 end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -161,8 +161,8 @@ function M.location_window(options)
     }
     options = vim.tbl_extend("keep", options, default_options)
 
-    local bufnr = options.bufnr or vim.fn.nvim_create_buf(false, true)
-    local win_id = vim.fn.nvim_open_win(bufnr, true, options)
+    local bufnr = options.bufnr or vim.api.nvim_create_buf(false, true)
+    local win_id = vim.api.nvim_open_win(bufnr, true, options)
 
     return {
         bufnr = bufnr,


### PR DESCRIPTION
`vim.fn` functions are written in vimsciprt, while `vim.api` functions are written in  lua. Thus, `vim.api` functions tend to perform better.