### PR TITLE
feat(term): add clear all functionality for terms

### DIFF
--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -72,4 +72,9 @@ M.sendCommand = function(idx, cmd, ...)
     end
 end
 
+M.clear_all = function()
+    log.trace("clear_all(): Clearing all terminals.")
+    terminals = {}
+end
+
 return M

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -74,6 +74,9 @@ end
 
 M.clear_all = function()
     log.trace("clear_all(): Clearing all terminals.")
+    for _, term in ipairs(terminals) do
+        vim.api.nvim_buf_delete(term.buf_id, { force = true })
+    end
     terminals = {}
 end
 


### PR DESCRIPTION
Added a function to simply clear/de-harpoon any previously harpooned terminals.
The terminals will still remain in the buffer pool but calling gotoTerminal will open up a fresh terminal.

Closes #91

First time contributing to anything but hope this is fine.