### PR TITLE
feat(term): configuration to run command automatically on send

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ require("harpoon").setup({
     global_settings = {
         save_on_toggle = false,
         save_on_change = true,
+        enter_on_sendcmd = false,
     },
     ... your other configs ...
 })
@@ -148,6 +149,8 @@ require("harpoon").setup({
   enable this option (on by default) harpoon will not save any changes to your
   file.  It is very unreliable to save your harpoon on exit (at least that is
   what I have found).
+* `enter_on_sendcmd` will set harpoon to run the command immediately as it's
+    passed to the terminal when calling `sendCommand`.
 
 #### Preconfigured Terminal Commands
 These are project specific commands that you wish to execute on the regular.

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -156,6 +156,7 @@ M.setup = function(config)
         global_settings = {
             ["save_on_toggle"] = false,
             ["save_on_change"] = true,
+            ["enter_on_sendcmd"] = false,
         },
     }, expand_dir(
         c_config

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -1,5 +1,6 @@
 local harpoon = require("harpoon")
 local log = require("harpoon.dev").log
+local global_config = harpoon.get_global_settings()
 
 local M = {}
 local terminals = {}
@@ -64,6 +65,10 @@ M.sendCommand = function(idx, cmd, ...)
 
     if type(cmd) == "number" then
         cmd = harpoon.get_term_config().cmds[cmd]
+    end
+
+    if global_config.enter_on_sendcmd then
+      cmd = cmd .. "\n"
     end
 
     if cmd then


### PR DESCRIPTION
When sending a command to the terminal, I want it to immediately start running. This is a configuration implementation to allow for this use case.