### PR TITLE
Add mark functionality per git branch

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -50,7 +50,7 @@ local function mark_config_key()
     if HarpoonConfig.mark_branch then
         return utils.branch_key()
     else
-        return utils.project_key
+        return utils.project_key()
     end
 end
 
@@ -72,9 +72,7 @@ local function ensure_correct_config(config)
             mark_config_key()
         )
         projects[mark_config_key()] = {
-            mark = {
-                marks = {},
-            },
+            mark = { marks = {} },
             term = {
                 cmds = {},
             },
@@ -102,9 +100,7 @@ local function ensure_correct_config(config)
 
     for idx, mark in pairs(marks) do
         if type(mark) == "string" then
-            mark = {
-                filename = mark,
-            }
+            mark = { filename = mark }
             marks[idx] = mark
         end
 
@@ -197,7 +193,7 @@ function M.refresh_projects_b4update()
         cache_config
     )
     -- save current runtime version of our project config for merging back in later
-    local cwd = vim.loop.cwd()
+    local cwd = mark_config_key()
     local current_p_config = {
         projects = {
             [cwd] = ensure_correct_config(HarpoonConfig).projects[cwd],
@@ -241,7 +237,7 @@ end
 
 function M.get_term_config()
     log.trace("get_term_config()")
-    return ensure_correct_config(HarpoonConfig).projects[utils.project_key].term
+    return ensure_correct_config(HarpoonConfig).projects[utils.project_key()].term
 end
 
 function M.get_mark_config()

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -58,12 +58,12 @@ end
 local function ensure_correct_config(config)
     log.trace("_ensure_correct_config()")
     local projects = config.projects
-    if projects[vim.loop.cwd()] == nil then
+    if projects[utils.mark_config_key()] == nil then
         log.debug(
             "ensure_correct_config(): No config found for:",
-            vim.loop.cwd()
+            utils.mark_config_key()
         )
-        projects[vim.loop.cwd()] = {
+        projects[utils.mark_config_key()] = {
             mark = {
                 marks = {},
             },
@@ -73,16 +73,19 @@ local function ensure_correct_config(config)
         }
     end
 
-    local proj = projects[vim.loop.cwd()]
+    local proj = projects[utils.mark_config_key()]
     if proj.mark == nil then
-        log.debug("ensure_correct_config(): No marks found for", vim.loop.cwd())
+        log.debug(
+            "ensure_correct_config(): No marks found for",
+            utils.mark_config_key()
+        )
         proj.mark = { marks = {} }
     end
 
     if proj.term == nil then
         log.debug(
             "ensure_correct_config(): No terminal commands found for",
-            vim.loop.cwd()
+            utils.mark_config_key()
         )
         proj.term = { cmds = {} }
     end
@@ -230,12 +233,12 @@ end
 
 function M.get_term_config()
     log.trace("get_term_config()")
-    return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].term
+    return ensure_correct_config(HarpoonConfig).projects[utils.project_key].term
 end
 
 function M.get_mark_config()
     log.trace("get_mark_config()")
-    return ensure_correct_config(HarpoonConfig).projects[vim.loop.cwd()].mark
+    return ensure_correct_config(HarpoonConfig).projects[utils.mark_config_key()].mark
 end
 
 function M.get_menu_config()

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -46,6 +46,14 @@ local function merge_table_impl(t1, t2)
     end
 end
 
+local function mark_config_key()
+    if HarpoonConfig.mark_branch then
+        return utils.branch_key()
+    else
+        return utils.project_key
+    end
+end
+
 local function merge_tables(...)
     log.trace("_merge_tables()")
     local out = {}
@@ -58,12 +66,12 @@ end
 local function ensure_correct_config(config)
     log.trace("_ensure_correct_config()")
     local projects = config.projects
-    if projects[utils.mark_config_key()] == nil then
+    if projects[mark_config_key()] == nil then
         log.debug(
             "ensure_correct_config(): No config found for:",
-            utils.mark_config_key()
+            mark_config_key()
         )
-        projects[utils.mark_config_key()] = {
+        projects[mark_config_key()] = {
             mark = {
                 marks = {},
             },
@@ -73,11 +81,11 @@ local function ensure_correct_config(config)
         }
     end
 
-    local proj = projects[utils.mark_config_key()]
+    local proj = projects[mark_config_key()]
     if proj.mark == nil then
         log.debug(
             "ensure_correct_config(): No marks found for",
-            utils.mark_config_key()
+            mark_config_key()
         )
         proj.mark = { marks = {} }
     end
@@ -85,7 +93,7 @@ local function ensure_correct_config(config)
     if proj.term == nil then
         log.debug(
             "ensure_correct_config(): No terminal commands found for",
-            utils.mark_config_key()
+            mark_config_key()
         )
         proj.term = { cmds = {} }
     end
@@ -238,7 +246,7 @@ end
 
 function M.get_mark_config()
     log.trace("get_mark_config()")
-    return ensure_correct_config(HarpoonConfig).projects[utils.mark_config_key()].mark
+    return ensure_correct_config(HarpoonConfig).projects[mark_config_key()].mark
 end
 
 function M.get_menu_config()

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -4,17 +4,22 @@ local Job = require("plenary.job")
 
 local M = {}
 
-local project_key = vim.loop.cwd()
-M.project_key = project_key
-M.branch_key = vim.loop.cwd()
 M.data_path = data_path
 
-function M.mark_config_key()
-    return string.gsub(vim.loop.cwd() .. '-' .. vim.fn.system('git branch --show-current'), "\n", "")
+function M.project_key()
+    return vim.loop.cwd()
+end
+
+function M.branch_key()
+    return string.gsub(
+        vim.loop.cwd() .. "-" .. vim.fn.system("git branch --show-current"),
+        "\n",
+        ""
+    )
 end
 
 function M.normalize_path(item)
-    return Path:new(item):make_relative(M.branch_key)
+    return Path:new(item):make_relative(M.project_key())
 end
 
 function M.get_os_command_output(cmd, cwd)
@@ -24,20 +29,24 @@ function M.get_os_command_output(cmd, cwd)
     end
     local command = table.remove(cmd, 1)
     local stderr = {}
-    local stdout, ret = Job:new({
-        command = command,
-        args = cmd,
-        cwd = cwd,
-        on_stderr = function(_, data)
-            table.insert(stderr, data)
-        end
-    }):sync()
+    local stdout, ret = Job
+        :new({
+            command = command,
+            args = cmd,
+            cwd = cwd,
+            on_stderr = function(_, data)
+                table.insert(stderr, data)
+            end,
+        })
+        :sync()
     return stdout, ret, stderr
 end
 
 function M.split_string(str, delimiter)
     local result = {}
-    for match in (str .. delimiter):gmatch("(.-)" .. delimiter) do table.insert(result, match) end
+    for match in (str .. delimiter):gmatch("(.-)" .. delimiter) do
+        table.insert(result, match)
+    end
     return result
 end
 

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -4,10 +4,15 @@ local Job = require("plenary.job")
 
 local M = {}
 
+M.project_key = vim.loop.cwd()
 M.data_path = data_path
 
+function M.mark_config_key()
+    return string.gsub(vim.loop.cwd() .. '-' .. vim.fn.system('git branch --show-current'), "\n", "")
+end
+
 function M.normalize_path(item)
-    return Path:new(item):make_relative(vim.loop.cwd())
+    return Path:new(item):make_relative(M.project_key)
 end
 
 function M.get_os_command_output(cmd, cwd)
@@ -17,24 +22,20 @@ function M.get_os_command_output(cmd, cwd)
     end
     local command = table.remove(cmd, 1)
     local stderr = {}
-    local stdout, ret = Job
-        :new({
-            command = command,
-            args = cmd,
-            cwd = cwd,
-            on_stderr = function(_, data)
-                table.insert(stderr, data)
-            end,
-        })
-        :sync()
+    local stdout, ret = Job:new({
+        command = command,
+        args = cmd,
+        cwd = cwd,
+        on_stderr = function(_, data)
+            table.insert(stderr, data)
+        end
+    }):sync()
     return stdout, ret, stderr
 end
 
 function M.split_string(str, delimiter)
     local result = {}
-    for match in (str .. delimiter):gmatch("(.-)" .. delimiter) do
-        table.insert(result, match)
-    end
+    for match in (str .. delimiter):gmatch("(.-)" .. delimiter) do table.insert(result, match) end
     return result
 end
 

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -4,7 +4,9 @@ local Job = require("plenary.job")
 
 local M = {}
 
-M.project_key = vim.loop.cwd()
+local project_key = vim.loop.cwd()
+M.project_key = project_key
+M.branch_key = vim.loop.cwd()
 M.data_path = data_path
 
 function M.mark_config_key()
@@ -12,7 +14,7 @@ function M.mark_config_key()
 end
 
 function M.normalize_path(item)
-    return Path:new(item):make_relative(M.project_key)
+    return Path:new(item):make_relative(M.branch_key)
 end
 
 function M.get_os_command_output(cmd, cwd)


### PR DESCRIPTION
# The Problem
When jumping from one feature branch to another with git, I struggled with the fact that Harpoon only saved my marked files based on the current project. However, for every feature, I need to change code in different files corresponding to the feature (which I want to be marked).

# What changed
With this PR, I changed the behaviour to make sure every branch in the project has its own marks. Each project still has its general terminal commands which I can configure and use over the different branches.

# How to configure
Toggle this feature with a `mark_branch` property in harpoon settings.

Example:
```lua
require("harpoon").setup({
    mark_branch = true,
    projects = {
        ["$HOME/Developer/your-project"] = {
            term = {
                cmds = {
                    "docker exec -it web bash",
                }
            }
        }
    }
})
```