### PR TITLE
Add convenience bindings for exiting quick menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ You can simply edit this list as if it were a document in vim.  `:wq` to save
 the new edits or `:q` to ignore the edits.  There is to save upon call to
 toggle if you prefer that way.
 
+You can also exit the list with `q` or `<ESC>`, which will also save your edits!
+
 ### Terminal Navigation
 #### Motivation for terminals in neovim
 I want to use the terminal since I can gF and <c-w>gF to any errors arising

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -99,6 +99,8 @@ M.toggle_quick_menu = function()
     vim.api.nvim_buf_set_option(Harpoon_bufh, "filetype", "harpoon")
     vim.api.nvim_buf_set_option(Harpoon_bufh, "buftype", "acwrite")
     vim.api.nvim_buf_set_option(Harpoon_bufh, "bufhidden", "delete")
+    vim.api.nvim_buf_set_keymap(Harpoon_bufh, "n", "q", ":q<CR>", { silent = true })
+    vim.api.nvim_buf_set_keymap(Harpoon_bufh, "n", "<ESC>", ":q<CR>", { silent = true })
     vim.api.nvim_buf_set_keymap(
         Harpoon_bufh,
         "n",


### PR DESCRIPTION
## What changed?
Added bindings to quit the quick menu using either `q` or `<ESC>`.

## How was it tested?
Seems to work on my local as advertised - I'm afraid I don't know much about lua or vim testing :(

## Misc. comments
Small easy PR for now, will look into quit on buffer change/ focus lost later :)