### PR TITLE
Print file name and slot after calling add_file()

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -183,8 +183,10 @@ M.add_file = function(file_name_or_buf_id)
     local buf_name = get_buf_name(file_name_or_buf_id)
     log.trace("add_file():", buf_name)
 
-    if M.valid_index(M.get_index_of(buf_name)) then
+    local buf_idx = M.get_index_of(buf_name)
+    if M.valid_index(buf_idx) then
         -- we don't alter file layout.
+        print("File", buf_name, "already exists in slot", buf_idx)
         return
     end
 
@@ -194,6 +196,8 @@ M.add_file = function(file_name_or_buf_id)
     harpoon.get_mark_config().marks[found_idx] = create_mark(buf_name)
     M.remove_empty_tail(false)
     emit_changed()
+
+    print("File", buf_name, "added to slot", found_idx)
 end
 
 -- _emit_on_changed == false should only be used internally


### PR DESCRIPTION
Hey Prime,
I have this problem with harpoon: When I call the `add_file()` command, I usually don't know in which slot the file will be placed. This usually results in calling `toggle_quick_menu()` right after to check the slot. This is especially a problem when harpoon has some files inside already. When I create a new project I can keep the slots in my head. Later on, I have to constantly check slots when adding new files.

I thought it might be a good idea to print to which slot was the current file placed in, after calling `add_file()`. Also, if the file is already placed in a slot, I would like it to print in which one.

I am not sure what the print message should look like (I am not that good at English :)). For now, this is how it looks like:
`print("File", buf_name, "added to slot", found_idx)`
`print("File", buf_name, "already exists in slot", buf_idx)`

Also, there could be an option in config when calling the `setup()`, to turn prints like this on.

If you don't like this idea, feel free to delete this PR. I will think of a different way to print the files just for me :)
