### PR TITLE
remove popup.nvim as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Simply install via your favorite plugin manager.
 
 ```vim
 Plug 'nvim-lua/plenary.nvim' " don't forget to add this one if you don't have it yet!
-Plug 'nvim-lua/popup.nvim'
 Plug 'ThePrimeagen/harpoon'
 ```
 

--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -1,5 +1,5 @@
 local harpoon = require("harpoon")
-local popup = require("popup")
+local popup = require("plenary.popup")
 local log = require("harpoon.dev").log
 local term = require("harpoon.term")
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -1,5 +1,5 @@
 local harpoon = require("harpoon")
-local popup = require("popup")
+local popup = require("plenary.popup")
 local Marked = require("harpoon.mark")
 local log = require("harpoon.dev").log
 


### PR DESCRIPTION
This removes popup.nvim as a dependency. Not so long ago, popup.nvim was moved into plenary and is planned to be archived later.

https://github.com/nvim-lua/plenary.nvim/pull/209