### PR TITLE
Quick menu improvements

### DIFF
--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -109,14 +109,13 @@ M.toggle_quick_menu = function()
         ":lua require('harpoon.cmd-ui').toggle_quick_menu()<CR>",
         { silent = true }
     )
-    -- TODO: maybe vim.fn.input() can be used to implement some select_menu_item
-    -- vim.api.nvim_buf_set_keymap(
-    --     Harpoon_cmd_bufh,
-    --     "n",
-    --     "<CR>",
-    --     ":lua require('harpoon.cmd-ui').select_menu_item()<CR>",
-    --     {}
-    -- )
+    vim.api.nvim_buf_set_keymap(
+        Harpoon_cmd_bufh,
+        "n",
+        "<CR>",
+        ":lua require('harpoon.cmd-ui').select_menu_item()<CR>",
+        {}
+    )
     vim.cmd(
         string.format(
             "autocmd BufWriteCmd <buffer=%s> :lua require('harpoon.cmd-ui').on_menu_save()",
@@ -137,6 +136,20 @@ M.toggle_quick_menu = function()
             Harpoon_cmd_bufh
         )
     )
+end
+
+M.select_menu_item = function()
+    log.trace("cmd-ui#select_menu_item()")
+    local cmd = vim.fn.line(".")
+    close_menu(true)
+    local answer = vim.fn.input("Terminal index (default to 1): ")
+    if answer == "" then
+        answer = "1"
+    end
+    local idx = tonumber(answer)
+    if idx then
+        term.sendCommand(idx, cmd)
+    end
 end
 
 M.on_menu_save = function()

--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -1,5 +1,6 @@
 local harpoon = require("harpoon")
 local popup = require("plenary.popup")
+local utils = require("harpoon.utils")
 local log = require("harpoon.dev").log
 local term = require("harpoon.term")
 
@@ -53,17 +54,13 @@ local function create_window()
     }
 end
 
-local function is_white_space(str)
-    return str:gsub("%s", "") == ""
-end
-
 local function get_menu_items()
     log.trace("_get_menu_items()")
     local lines = vim.api.nvim_buf_get_lines(Harpoon_cmd_bufh, 0, -1, true)
     local indices = {}
 
     for _, line in pairs(lines) do
-        if not is_white_space(line) then
+        if not utils.is_white_space(line) then
             table.insert(indices, line)
         end
     end

--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -95,6 +95,20 @@ M.toggle_quick_menu = function()
     vim.api.nvim_buf_set_option(Harpoon_cmd_bufh, "filetype", "harpoon")
     vim.api.nvim_buf_set_option(Harpoon_cmd_bufh, "buftype", "acwrite")
     vim.api.nvim_buf_set_option(Harpoon_cmd_bufh, "bufhidden", "delete")
+    vim.api.nvim_buf_set_keymap(
+        Harpoon_cmd_bufh,
+        "n",
+        "q",
+        ":lua require('harpoon.cmd-ui').toggle_quick_menu()<CR>",
+        { silent = true }
+    )
+    vim.api.nvim_buf_set_keymap(
+        Harpoon_cmd_bufh,
+        "n",
+        "<ESC>",
+        ":lua require('harpoon.cmd-ui').toggle_quick_menu()<CR>",
+        { silent = true }
+    )
     -- TODO: maybe vim.fn.input() can be used to implement some select_menu_item
     -- vim.api.nvim_buf_set_keymap(
     --     Harpoon_cmd_bufh,

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -1,6 +1,7 @@
 local harpoon = require("harpoon")
 local popup = require("plenary.popup")
 local Marked = require("harpoon.mark")
+local utils = require("harpoon.utils")
 local log = require("harpoon.dev").log
 
 local M = {}
@@ -60,12 +61,9 @@ local function get_menu_items()
     local lines = vim.api.nvim_buf_get_lines(Harpoon_bufh, 0, -1, true)
     local indices = {}
 
-    for idx = 1, #lines do
-        local space_location = string.find(lines[idx], " ")
-        log.debug("_get_menu_items():", idx, space_location)
-
-        if space_location ~= nil then
-            table.insert(indices, string.sub(lines[idx], space_location + 1))
+    for _, line in pairs(lines) do
+        if not utils.is_white_space(line) then
+            table.insert(indices, line)
         end
     end
 
@@ -91,9 +89,10 @@ M.toggle_quick_menu = function()
         if file == "" then
             file = "(empty)"
         end
-        contents[idx] = string.format("%d %s", idx, file)
+        contents[idx] = string.format("%s", file)
     end
 
+    vim.api.nvim_win_set_option(Harpoon_win_id, "number", true)
     vim.api.nvim_buf_set_name(Harpoon_bufh, "harpoon-menu")
     vim.api.nvim_buf_set_lines(Harpoon_bufh, 0, #contents, false, contents)
     vim.api.nvim_buf_set_option(Harpoon_bufh, "filetype", "harpoon")

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -6,6 +6,9 @@ local M = {
     normalize_path = function(item)
         return Path:new(item):make_relative(vim.loop.cwd())
     end,
+    is_white_space = function(str)
+        return str:gsub("%s", "") == ""
+    end,
 }
 
 return M


### PR DESCRIPTION
Edited marks quick menu to use 'number' option instead of prefixing lines by indexes (which were no longer valid when reordering marks), in the same way as cmd quick menu.

Added 'q' and '\<ESC>' keymaps to cmd quick menu to close the window as in the marks quick menu.
And added \<CR> keymap to execute the command under the user's cursor (with a prompt to type the terminal index).

Closes #113