### PR TITLE
fix #68 marks not saving due to over-writing by multiple vim instances

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -179,16 +179,18 @@ M.get_global_settings = function()
     return HarpoonConfig.global_settings
 end
 
-
 -- refresh all projects from disk, except our current one
 M.refresh_projects_b4update = function()
-    log.trace("refresh_projects_b4update(): refreshing other projects", cache_config)
+    log.trace(
+        "refresh_projects_b4update(): refreshing other projects",
+        cache_config
+    )
     -- save current runtime version of our project config for merging back in later
     local cwd = vim.loop.cwd()
     local current_p_config = {
         projects = {
-            [cwd] =  ensure_correct_config(HarpoonConfig).projects[cwd]
-        }
+            [cwd] = ensure_correct_config(HarpoonConfig).projects[cwd],
+        },
     }
 
     -- erase all projects from global config, will be loaded back from disk
@@ -199,7 +201,10 @@ M.refresh_projects_b4update = function()
     local ok2, c_config = pcall(read_config, cache_config)
 
     if not ok2 then
-        log.debug("refresh_projects_b4update(): No cache config present at", cache_config)
+        log.debug(
+            "refresh_projects_b4update(): No cache config present at",
+            cache_config
+        )
         c_config = {}
     end
     -- don't override non-project config in HarpoonConfig later
@@ -211,7 +216,8 @@ M.refresh_projects_b4update = function()
     local complete_config = merge_tables(
         HarpoonConfig,
         expand_dir(c_config),
-        expand_dir(current_p_config))
+        expand_dir(current_p_config)
+    )
 
     -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
     -- an object for vim.loop.cwd()

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -120,6 +120,9 @@ local function expand_dir(config)
 end
 
 M.save = function()
+    -- first refresh from disk everything but our project
+    M.refresh_projects_b4update()
+
     log.trace("save(): Saving cache config to", cache_config)
     Path:new(cache_config):write(vim.fn.json_encode(HarpoonConfig), "w")
 end
@@ -174,6 +177,49 @@ end
 M.get_global_settings = function()
     log.trace("get_global_settings()")
     return HarpoonConfig.global_settings
+end
+
+
+-- refresh all projects from disk, except our current one
+M.refresh_projects_b4update = function()
+    log.trace("refresh_projects_b4update(): refreshing other projects", cache_config)
+    -- save current runtime version of our project config for merging back in later
+    local cwd = vim.loop.cwd()
+    local current_p_config = {
+        projects = {
+            [cwd] =  ensure_correct_config(HarpoonConfig).projects[cwd]
+        }
+    }
+
+    -- erase all projects from global config, will be loaded back from disk
+    HarpoonConfig.projects = nil
+
+    -- this reads a stale version of our project but up-to-date versions
+    -- of all other projects
+    local ok2, c_config = pcall(read_config, cache_config)
+
+    if not ok2 then
+        log.debug("refresh_projects_b4update(): No cache config present at", cache_config)
+        c_config = {}
+    end
+    -- don't override non-project config in HarpoonConfig later
+    c_config = { projects = c_config.projects }
+
+    -- erase our own project, will be merged in from current_p_config later
+    c_config.projects[cwd] = nil
+
+    local complete_config = merge_tables(
+        HarpoonConfig,
+        expand_dir(c_config),
+        expand_dir(current_p_config))
+
+    -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
+    -- an object for vim.loop.cwd()
+    ensure_correct_config(complete_config)
+
+    HarpoonConfig = complete_config
+    log.debug("refresh_projects_b4update(): Complete config", HarpoonConfig)
+    log.trace("refresh_projects_b4update(): log_key", Dev.get_log_key())
 end
 
 M.get_term_config = function()


### PR DESCRIPTION
As described in #68, the global HarpoonConfig of vim instance 2 does not
get updated if marks in vim instance 1 change, as described by
@freehaha.

This fix remedies the situation by refreshing marks for all other
projects before saving HarpoonConfig to disk.