### PR TITLE
feat(bindings): add ctrl + c to close the quick menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ view all project marks with:
 ```lua
 :lua require("harpoon.ui").toggle_quick_menu()
 ```
-you can go up and down the list, enter, delete or reorder. `q` and `<ESC>` exit and save the menu
+you can go up and down the list, enter, delete or reorder. `q`, `<ESC>` and `<C-c>` exit and save the menu
 
 you also can switch to any mark without bringing up the menu, use the below with the desired mark index
 ```lua

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -115,6 +115,13 @@ function M.toggle_quick_menu()
     vim.api.nvim_buf_set_keymap(
         Harpoon_bufh,
         "n",
+        "<C-c>",
+        "<Cmd>lua require('harpoon.ui').toggle_quick_menu()<CR>",
+        { silent = true }
+    )
+    vim.api.nvim_buf_set_keymap(
+        Harpoon_bufh,
+        "n",
         "<CR>",
         "<Cmd>lua require('harpoon.ui').select_menu_item()<CR>",
         {}


### PR DESCRIPTION
# What changed?
- Added bindings to quit the quick menu using <C-c>

# How was it tested?
Work on my local just have to try <C-c> on quick menu. 

