### PR TITLE
fixed inconsistent jumping between similarly named files

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -164,7 +164,7 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local buf_id = vim.fn.bufnr(vim.fn.getcwd().. '/' .. mark.filename, true)
+    local buf_id = vim.fn.bufnr(vim.fn.getcwd() .. "/" .. mark.filename, true)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -164,7 +164,7 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local buf_id = vim.fn.bufnr(mark.filename, true)
+    local buf_id = vim.fn.bufnr(vim.fn.getcwd().. '/' .. mark.filename, true)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)


### PR DESCRIPTION
Harpoon is not able to differentiate between 2 files consistently using only the cwd path and
the filename.

as an example imagine you have a project with the following structure:
```lua
lua/plugins/init.lua
init.lua
```
both files are already marked by harpoon.

Opening `lua/plugins/init.lua` first, and then trying to jump
to `init.lua`, is not going to work, the bug happens since bufnr thinks that both files are the
same so it returns the same buffer number as `lua/plugins/init.lua`, which means a buffer is not
created, adding the full path prefix to the bufnr fixes this issue.

