### PR TITLE
Add ability to pass any tmux pane identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ lua require("harpoon.tmux").sendCommand(1, "ls -La")    -- sends ls -La to tmux 
 lua require("harpoon.tmux").sendCommand(1, 1)           -- sends command 1 to tmux window 1
 ```
 
+`sendCommand` and `goToTerminal` also accept any valid [tmux pane identifier](https://man7.org/linux/man-pages/man1/tmux.1.html#COMMANDS).
+```lua
+lua require("harpoon.tmux").gotoTerminal("{down-of}")   -- focus the pane directly below
+lua require("harpoon.tmux").sendCommand("%3", "ls")     -- send a command to the pane with id '%3'
+```
+
 ### Telescope Support
 1st register harpoon as a telescope extension
 ```lua


### PR DESCRIPTION
Currently, it is not possible to pass an existing tmux pane ID to harpoon. This can be useful to run a terminal command in a split pane in the same window, for example. 

This PR adds the ability to execute commands like 
```lua
lua require("harpoon.tmux").gotoTerminal("{down-of}")   -- focus the pane directly below
lua require("harpoon.tmux").sendCommand("%3", "ls")     -- send a command to the pane with id '%3'
```