### PR TITLE
harpoon.ui: handle absolute paths

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -164,7 +164,7 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local buf_id = vim.fn.bufnr(vim.fn.getcwd() .. "/" .. mark.filename, true)
+    local buf_id = vim.fn.bufnr(vim.api.cwd() .. "/" .. mark.filename, true)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -164,7 +164,11 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local buf_id = vim.fn.bufnr(vim.api.cwd() .. "/" .. mark.filename, true)
+    local filename = mark.filename
+    if filename:sub(1, 1) ~= "/" then
+        filename = vim.loop.cwd() .. "/" .. mark.filename
+    end
+    local buf_id = vim.fn.bufnr(filename, true)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)


### PR DESCRIPTION
If the filename is an absolute path then there is no need to
prepend the path with the current directory.

Detect absolute paths and open them as-is.

This fixes harpoon when editing files through symlinks
that point to other places on the filesystem.