### PR TITLE
refactor: improve git branch specific marks impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ feedback for harpoon (or me), make an issue!
 
 ## ⇁ The Problems:
 1. You're working on a codebase. medium, large, tiny, whatever. You find
-yourself frequenting a small set of files and you are tired of using a fuzzy finder, 
+yourself frequenting a small set of files and you are tired of using a fuzzy finder,
 `:bnext` & `:bprev` are getting too repetitive, alternate file doesn't quite cut it, etc etc.
 1. You want to execute some project specific commands or have any number of
 persistent terminals that can be easily navigated to.
@@ -133,7 +133,10 @@ global_settings = {
     tmux_autoclose_windows = false,
 
     -- filetypes that you want to prevent from adding to the harpoon list menu.
-    excluded_filetypes = { "harpoon" }
+    excluded_filetypes = { "harpoon" },
+
+    -- set marks specific to each git branch inside git repository
+    mark_branch = false,
 }
 ```
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -46,8 +46,9 @@ local function merge_table_impl(t1, t2)
     end
 end
 
-local function mark_config_key()
-    if HarpoonConfig.mark_branch then
+local function mark_config_key(global_settings)
+    global_settings = global_settings or M.get_global_settings()
+    if global_settings.mark_branch then
         return utils.branch_key()
     else
         return utils.project_key()
@@ -66,12 +67,10 @@ end
 local function ensure_correct_config(config)
     log.trace("_ensure_correct_config()")
     local projects = config.projects
-    if projects[mark_config_key()] == nil then
-        log.debug(
-            "ensure_correct_config(): No config found for:",
-            mark_config_key()
-        )
-        projects[mark_config_key()] = {
+    local mark_key = mark_config_key(config.global_settings)
+    if projects[mark_key] == nil then
+        log.debug("ensure_correct_config(): No config found for:", mark_key)
+        projects[mark_key] = {
             mark = { marks = {} },
             term = {
                 cmds = {},
@@ -79,19 +78,16 @@ local function ensure_correct_config(config)
         }
     end
 
-    local proj = projects[mark_config_key()]
+    local proj = projects[mark_key]
     if proj.mark == nil then
-        log.debug(
-            "ensure_correct_config(): No marks found for",
-            mark_config_key()
-        )
+        log.debug("ensure_correct_config(): No marks found for", mark_key)
         proj.mark = { marks = {} }
     end
 
     if proj.term == nil then
         log.debug(
             "ensure_correct_config(): No terminal commands found for",
-            mark_config_key()
+            mark_key
         )
         proj.term = { cmds = {} }
     end
@@ -169,6 +165,7 @@ function M.setup(config)
             ["enter_on_sendcmd"] = false,
             ["tmux_autoclose_windows"] = false,
             ["excluded_filetypes"] = { "harpoon" },
+            ["mark_branch"] = false,
         },
     }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
 

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -11,11 +11,20 @@ function M.project_key()
 end
 
 function M.branch_key()
-    return string.gsub(
-        vim.loop.cwd() .. "-" .. vim.fn.system("git branch --show-current"),
-        "\n",
-        ""
-    )
+    -- `git branch --show-current` requires Git v2.22.0+ so going with more
+    -- widely available command
+    local branch = M.get_os_command_output({
+        "git",
+        "rev-parse",
+        "--abbrev-ref",
+        "HEAD",
+    })[1]
+
+    if branch then
+        return vim.loop.cwd() .. "-" .. branch
+    else
+        return M.project_key()
+    end
 end
 
 function M.normalize_path(item)


### PR DESCRIPTION
A few changes from #98 

1. Use `git rev-parse --abbrev-ref HEAD` over `git branch --show-current` as it's more commonly available on old git versions.
2. Reduced the number of calls to the aforementioned command to improve performance
3. Make `mark_branch` a global_setting
4. Add `mark_branch` under global_settings in README