### PR TITLE
Feat: Allow user to switch back to the main neovim window

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ a new terminal is created.
 lua require("harpoon.term").gotoTerminal(1)             -- navigates to term 1
 ```
 
+Once you switch to a terminal you can always switch back to neovim, this is a
+little bash script that will switch to the window which is running neovim.
+
+In your `tmux.conf` (or anywhere you have keybinds), add this
+```bash
+bind-key -r G run-shell "path-to-harpoon/harpoon/scripts/tmux/switch-back-to-nvim"
+```
+
+
 ### Commands to Terminals
 commands can be sent to any terminal
 ```lua

--- a/scripts/tmux/switch-back-to-nvim
+++ b/scripts/tmux/switch-back-to-nvim
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Make sure tmux is running
+tmux_running=$(pgrep tmux)
+
+if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
+    echo "tmux needs to be running"
+    exit 1
+fi
+
+# Switch to a window called nvim in tmux - if it exists
+session_name=$(tmux display-message -p "#S")
+
+tmux switch-client -t "$session_name:nvim"


### PR DESCRIPTION
Hiya, I have been using harpoon for a while, and I love the fact that I can quickly to switch to my tmux windows, but I was never able to switch back to neovim as smoothly. So I have wrote this little script that allows you to switch back to my neovim session.

**If you have more then one window open running neovim at the moment it will not work, I'm working on a fix for that.**