### PR TITLE
Fix bug where action_utils was not sourced

### DIFF
--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -1,5 +1,6 @@
 local action_set = require("telescope.actions.set")
 local action_state = require("telescope.actions.state")
+local action_utils = require("telescope.actions.utils")
 local entry_display = require("telescope.pickers.entry_display")
 local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")


### PR DESCRIPTION
Fix bug where action_utils was not sourced which is required for multiselection mark deletion