### PR TITLE
feat: add base dirs (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ global_settings = {
 
     -- set marks specific to each git branch inside git repository
     mark_branch = false,
+
+    -- all marks that belong under a base directory will be shown in the harpoon menu for that base directory
+    -- this feature does not work if mark_branch is true
+    -- to clear the list of base_dirs, specify an empty table (do not remove the base_dirs key entirely)
+    base_dirs = { }
 }
 ```
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -34,6 +34,11 @@ HarpoonConfig = HarpoonConfig or {}
 -- tbl_deep_extend does not work the way you would think
 local function merge_table_impl(t1, t2)
     for k, v in pairs(t2) do
+        if (k == 'base_dirs') then
+            -- we want the base_dirs from t2 (user config) to overwrite t1
+            -- eg if a base dir is removed from user config
+            t1[k] = v
+        end
         if type(v) == "table" then
             if type(t1[k]) == "table" then
                 merge_table_impl(t1[k], v)
@@ -160,6 +165,7 @@ function M.setup(config)
     local complete_config = merge_tables({
         projects = {},
         global_settings = {
+            ["base_dirs"] = {},
             ["save_on_toggle"] = false,
             ["save_on_change"] = true,
             ["enter_on_sendcmd"] = false,
@@ -168,6 +174,9 @@ function M.setup(config)
             ["mark_branch"] = false,
         },
     }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
+
+    -- make global settings available so the utils module can use it at this point
+    HarpoonConfig.global_settings = complete_config.global_settings
 
     -- There was this issue where the vim.loop.cwd() didn't have marks or term, but had
     -- an object for vim.loop.cwd()

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -166,7 +166,7 @@ function M.nav_file(id)
     local mark = Marked.get_marked_file(idx)
     local filename = mark.filename
     if filename:sub(1, 1) ~= "/" then
-        filename = vim.loop.cwd() .. "/" .. mark.filename
+        filename = utils.project_key() .. "/" .. mark.filename
     end
     local buf_id = vim.fn.bufnr(filename, true)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -7,7 +7,22 @@ local M = {}
 M.data_path = data_path
 
 function M.project_key()
-    return vim.loop.cwd()
+    -- get the base dir if found, if not, return cwd
+    local global_settings = HarpoonConfig.global_settings
+    local baseDirs = global_settings.base_dirs
+    local cwd = vim.loop.cwd()
+
+    if (baseDirs) then
+        for _, baseDir in pairs(baseDirs) do
+            local childDir = Path:new(cwd):make_relative(baseDir)
+            if (baseDir == "" or childDir == cwd) then
+            else
+                return baseDir
+            end
+        end
+    end
+
+    return cwd
 end
 
 function M.branch_key()


### PR DESCRIPTION
# Add base dirs to fix #73

## Current Problem:
<img width="2315" alt="image" src="https://user-images.githubusercontent.com/7954426/164881773-bfa9f4f1-1be4-4d38-a2af-f79812a29fb4.png">

- The harpoon menu does not show, in a single menu, all the marks that I make in a mono repo
  - Instead the marks from child project a are shown in the harpoon menu that I open when in child project a
  - The marks from child project b are shown separately in another harpoon menu when opened from child project b
- This is caused by lsp changing the cwd when I open a file from a child project

## Solution:
<img width="2146" alt="image" src="https://user-images.githubusercontent.com/7954426/164887593-3fb8bdd4-ec58-4d87-8900-b5ffbbbebf3f.png">

- Add a base_dirs key to global settings which can store an array of base_dirs
- Harpoon will get cwd and then refer to base_dirs when trying to determine the current project key
- If cwd is a child of base_dir, use the base_dir key instead

## Note:

- To remove a base_dir that has been set up previously, specify base_dirs = {}. Do not remove the base_dirs global settings key entirely when calling harpoon.setup
- @ThePrimeagen I don't know if this works with git worktrees ... I never could get your git worktrees plugin to work ... someone test ? :D 

## Improvements:

- Does anyone know how to determine if a directory is a child of a filepath? I implement this hackily using Plenary's `Path:new(cwd):make_relative(baseDir)` 

## Limitations

- This **does not work** with the mark_branch=true global setting. (Because trying to figure out if /path/to/a/dir-feature-branch-1 is a child of /path/to/a/dir is painful. If anyone wants to take a stab at this .... :D
- I hope i did not break the tmux commands ... I notice they use cwd ... ¯\_(ツ)_/¯

## Questions
- How do send commands work in a mono repo? should the cwd of a command be the basedir ?