### PR TITLE
fix(nav-file): bufnr failure when trying to create the buffer

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -155,6 +155,15 @@ function M.on_menu_save()
     Marked.set_mark_list(get_menu_items())
 end
 
+local function get_or_create_buffer(filename)
+    local buf_exists = vim.fn.bufexists(filename) ~= 0
+    if buf_exists then
+        return vim.fn.bufnr(filename)
+    end
+
+    return vim.fn.bufadd(filename)
+end
+
 function M.nav_file(id)
     log.trace("nav_file(): Navigating to", id)
     local idx = Marked.get_index_of(id)
@@ -168,7 +177,7 @@ function M.nav_file(id)
     if filename:sub(1, 1) ~= "/" then
         filename = vim.loop.cwd() .. "/" .. mark.filename
     end
-    local buf_id = vim.fn.bufnr(filename, true)
+    local buf_id = get_or_create_buffer(filename)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)


### PR DESCRIPTION
I'm not perfectly sure if this should be upstreamed, but seems like passing true to bufnr `create` argument now fails.
This fixes this issue by adding a new buffer with bufadd when the buffer does not exist in the buffer list.

The issue can be reproduced as follow:
- open a project, add a mark to a file
- close the project
- reopen the project
- open harpoon ui
- try to navigate to the marked file

You should get something like:
```
E5108: Error executing lua Vim:E94: No matching buffer for FILE
stack traceback:
        [C]: in function 'bufnr'
        ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:171: in function 'nav_file
'
        ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:150: in function 'select_m
enu_item'
        [string ":lua"]:1: in main chunk
```