### PR TITLE
Try to switch back to window named "nvim" only if at least one exists

### DIFF
--- a/scripts/tmux/switch-back-to-nvim
+++ b/scripts/tmux/switch-back-to-nvim
@@ -10,5 +10,16 @@ fi
 
 # Switch to a window called nvim in tmux - if it exists
 session_name=$(tmux display-message -p "#S")
+windows=$(tmux list-windows)
+window_name="nvim"
 
-tmux switch-client -t "$session_name:nvim"
+if [[ -n $session_name ]]; then
+    for window in "${windows[@]}"
+    do
+        if [[ $window == *"$window_name"* ]]
+        then
+            tmux switch-client -t "$session_name:$window_name"
+            exit 0
+        fi
+    done
+fi


### PR DESCRIPTION
Now if i try to use switch-back-to-nvim when window named "nvim" doesn't exist there is ugly message, that tmux command returned with exit status 1. I've added small check to verify if there is one in current session.