### PR TITLE
Allow user to have global marks

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -109,11 +109,8 @@ local function ensure_correct_config(config)
             marks[idx] = mark
         end
 
-        if config.global_project then
-            marks[idx].filename = mark.filename
-        else
-            marks[idx].filename = utils.normalize_path(mark.filename)
-        end
+        marks[idx].filename = utils.normalize_path(mark.filename, config.global_project)
+
     end
 
     return config

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -46,12 +46,21 @@ local function merge_table_impl(t1, t2)
     end
 end
 
+local function get_project_key(global_settings)
+    global_settings = global_settings or M.get_global_settings()
+    if global_settings.global_project then
+        return global_settings.global_project
+    else
+        return utils.project_key()
+    end
+end
+
 local function mark_config_key(global_settings)
     global_settings = global_settings or M.get_global_settings()
     if global_settings.mark_branch then
         return utils.branch_key()
     else
-        return utils.project_key()
+        return get_project_key(global_settings)
     end
 end
 
@@ -100,7 +109,11 @@ local function ensure_correct_config(config)
             marks[idx] = mark
         end
 
-        marks[idx].filename = utils.normalize_path(mark.filename)
+        if config.global_project then
+            marks[idx].filename = mark.filename
+        else
+            marks[idx].filename = utils.normalize_path(mark.filename)
+        end
     end
 
     return config
@@ -234,7 +247,7 @@ end
 
 function M.get_term_config()
     log.trace("get_term_config()")
-    return ensure_correct_config(HarpoonConfig).projects[utils.project_key()].term
+    return ensure_correct_config(HarpoonConfig).projects[mark_config_key()].term
 end
 
 function M.get_mark_config()

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -6,6 +6,7 @@ local log = require("harpoon.dev").log
 -- of procedural all the things
 local M = {}
 local callbacks = {}
+local relative_path = harpoon.get_global_settings().global_project
 
 -- I am trying to avoid over engineering the whole thing.  We will likely only
 -- need one event emitted
@@ -58,9 +59,9 @@ end
 local function get_buf_name(id)
     log.trace("_get_buf_name():", id)
     if id == nil then
-        return utils.normalize_path(vim.api.nvim_buf_get_name(0))
+        return utils.normalize_path(vim.api.nvim_buf_get_name(0), relative_path)
     elseif type(id) == "string" then
-        return utils.normalize_path(id)
+        return utils.normalize_path(id, relative_path)
     end
 
     local idx = M.get_index_of(id)
@@ -149,7 +150,7 @@ function M.get_index_of(item)
     end
 
     if type(item) == "string" then
-        local relative_item = utils.normalize_path(item)
+        local relative_item = utils.normalize_path(item, relative_path)
         for idx = 1, M.get_length() do
             if M.get_marked_file_name(idx) == relative_item then
                 return idx
@@ -181,7 +182,7 @@ function M.status(bufnr)
         buf_name = vim.api.nvim_buf_get_name(0)
     end
 
-    local norm_name = utils.normalize_path(buf_name)
+    local norm_name = utils.normalize_path(buf_name, relative_path)
     local idx = M.get_index_of(norm_name)
 
     if M.valid_index(idx) then

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -165,7 +165,10 @@ function M.nav_file(id)
 
     local mark = Marked.get_marked_file(idx)
     local filename = mark.filename
-    if filename:sub(1, 1) ~= "/" then
+    local relative_path = harpoon.get_global_settings().global_project
+    if relative_path then
+        filename = relative_path .. "/" .. mark.filename
+    elseif filename:sub(1, 1) ~= "/" then
         filename = vim.loop.cwd() .. "/" .. mark.filename
     end
     local buf_id = vim.fn.bufnr(filename, true)

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -27,8 +27,12 @@ function M.branch_key()
     end
 end
 
-function M.normalize_path(item)
-    return Path:new(item):make_relative(M.project_key())
+function M.normalize_path(item, relative_path)
+    if relative_path then
+        return Path:new(item):make_relative(relative_path)
+    else
+        return Path:new(item):make_relative(M.project_key())
+    end
 end
 
 function M.get_os_command_output(cmd, cwd)


### PR DESCRIPTION
Hello.
I made similar PR before, but looks like it overlaped with some big changes. So I made everything anew.
https://github.com/ThePrimeagen/harpoon/pull/122 <--- old pr

This pull request will allow user to add global marks, the user will be able to decide where the root folder should reside. The most common case (my case) is to set the root folder as a git root folder like
       ` global_project = vim.fn[  's:find_git_root'  ]()`
where
```
  function! s:find_git_root()
    return system('git rev-parse --show-toplevel 2> /dev/null')[:-2]
  endfunction
```

There is also an feature request issue for this functionality https://github.com/ThePrimeagen/harpoon/issues/99

Hope this feature will be usefull.
