### PR TITLE
Added functions to allow scripting of whether to open a new terminal

### DIFF
--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -108,6 +108,17 @@ function M.valid_index(idx)
     return true
 end
 
+function M.num_terminals()
+    return table.maxn(terminals)
+end
+
+function M.valid_terminal_index(idx)
+    if idx == nil or idx > M.num_terminals() or idx <= 0 then
+        return false
+    end
+    return true
+end
+
 function M.emit_changed()
     log.trace("_emit_changed()")
     if harpoon.get_global_settings().save_on_change then


### PR DESCRIPTION
I wanted to run a command that queries whether there is already a terminal (and if not, open a split window, create a new terminal there, and return to the original window, but that happens in my code, not harpoon).  These functions allow me to do that.