### PR TITLE
feat: Make current file easily noticeable

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -77,6 +77,19 @@ function M.toggle_quick_menu()
         return
     end
 
+    local curr_file = utils.normalize_path(vim.api.nvim_buf_get_name(0))
+    vim.cmd(
+        string.format(
+            "autocmd Filetype harpoon " ..
+                "let path = '%s' | call clearmatches() | " ..
+                -- move the cursor to the line containing the current filename
+                "call search('\\V'.path.'\\$') | " ..
+                -- add a hl group to that line
+                "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
+            curr_file:gsub("\\", "\\\\")
+        )
+    )
+
     local win_info = create_window()
     local contents = {}
     local global_config = harpoon.get_global_settings()

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -80,12 +80,12 @@ function M.toggle_quick_menu()
     local curr_file = utils.normalize_path(vim.api.nvim_buf_get_name(0))
     vim.cmd(
         string.format(
-            "autocmd Filetype harpoon " ..
-                "let path = '%s' | call clearmatches() | " ..
+            "autocmd Filetype harpoon "
+                .. "let path = '%s' | call clearmatches() | "
                 -- move the cursor to the line containing the current filename
-                "call search('\\V'.path.'\\$') | " ..
+                .. "call search('\\V'.path.'\\$') | "
                 -- add a hl group to that line
-                "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
+                .. "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
             curr_file:gsub("\\", "\\\\")
         )
     )


### PR DESCRIPTION
This PR contains two changes that revolve around a single purpose - to make the currently opened file easily noticeable in the quick menu.

The first one is non-breaking and it adds a highlight group (`HarpoonCurrentFile`, not linked by default) on the line that contains the currently opened file.

The second is somewhat breaking and moves the cursor to the line that contains the currently opened file when you open the quick menu.

If the current buffer is not Harpooned, they do nothing.

Here's a preview to help explain the features.

[Peek 2022-08-23 22-40.webm](https://user-images.githubusercontent.com/543561/186251943-0021f2f3-fe6c-48a7-9277-94dff3dc55e9.webm)

(Here, `HarpoonCurrentFile` is linked to Search - `:highlight link HarpoonCurrentFile Search`)

Rationale: In the couple of months that I've been using Harpoon, I often found myself editing the harpoon list around the currently opened file (move it to the top, or remove all other files, etc), so making it more easily noticeable feels natural.