### PR TITLE
Fix: Uses Tmux pane_id instead of window ids. 

### DIFF
--- a/lua/harpoon/tmux.lua
+++ b/lua/harpoon/tmux.lua
@@ -55,12 +55,14 @@ local function terminal_exists(window_id)
     local window_list, _, _ = utils.get_os_command_output({
         "tmux",
         "list-windows",
+        "-F",
+        "#{pane_id}"
     }, vim.loop.cwd())
 
     -- This has to be done this way because tmux has-session does not give
     -- updated results
     for _, line in pairs(window_list) do
-        local window_info = utils.split_string(line, "@")[2]
+        local window_info = line
 
         if string.find(window_info, string.sub(window_id, 2)) then
             exists = true


### PR DESCRIPTION
The list window command will now output pane_ids instead of window_ids since pane_ids are stored in the Lua table `tmux_windows` as shown by the [tmux format flag](https://github.com/ThePrimeagen/harpoon/blob/f4aff5bf9b512f5a85fe20eb1dcf4a87e512d971/lua/harpoon/tmux.lua#L34).