### PR TITLE
feat: send command to tmux from Harpoon menu

### DIFF
--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -3,6 +3,7 @@ local popup = require("plenary.popup")
 local utils = require("harpoon.utils")
 local log = require("harpoon.dev").log
 local term = require("harpoon.term")
+local tmux = require("harpoon.tmux")
 
 local M = {}
 
@@ -142,13 +143,21 @@ function M.select_menu_item()
     log.trace("cmd-ui#select_menu_item()")
     local cmd = vim.fn.line(".")
     close_menu(true)
-    local answer = vim.fn.input("Terminal index (default to 1): ")
-    if answer == "" then
-        answer = "1"
-    end
-    local idx = tonumber(answer)
-    if idx then
-        term.sendCommand(idx, cmd)
+    if tmux.is_tmux then
+        local idx = vim.fn.input("Tmux index (default to {next}): ")
+        if idx == "" then
+            idx = "{next}"
+        end
+        tmux.sendCommand(idx, cmd)
+    else
+        local idx = vim.fn.input("Terminal index (default to 1): ")
+        if idx == "" then
+            idx = "1"
+        end
+        local idx = tonumber(idx)
+        if idx then
+            term.sendCommand(idx, cmd)
+        end
     end
 end
 

--- a/lua/harpoon/tmux.lua
+++ b/lua/harpoon/tmux.lua
@@ -3,14 +3,13 @@ local log = require("harpoon.dev").log
 local global_config = harpoon.get_global_settings()
 local utils = require("harpoon.utils")
 
-local M = {}
+local M = { is_tmux = false }
+
 local tmux_windows = {}
 
 if global_config.tmux_autoclose_windows then
-    local harpoon_tmux_group = vim.api.nvim_create_augroup(
-        "HARPOON_TMUX",
-        { clear = true }
-    )
+    local harpoon_tmux_group =
+        vim.api.nvim_create_augroup("HARPOON_TMUX", { clear = true })
 
     vim.api.nvim_create_autocmd("VimLeave", {
         callback = function()
@@ -19,6 +18,12 @@ if global_config.tmux_autoclose_windows then
         group = harpoon_tmux_group,
     })
 end
+
+local function get_tmux()
+    return os.getenv("TMUX")
+end
+
+M.is_tmux = get_tmux() ~= nil
 
 local function create_terminal()
     log.trace("tmux: _create_terminal())")


### PR DESCRIPTION
@ThePrimeagen This PR is my attempt to follow up https://github.com/ThePrimeagen/harpoon/issues/202

In the demo, the left side is nvim opened within Tmux, the right side is opened without Tmux. Harpoon will know if we run into Tmux session, then give a similar popup message to ask user to address which pane they would like to send command, default is `{next}` token.


https://user-images.githubusercontent.com/1514823/190280787-486a176b-3396-4d38-9f7b-bc75953db6c6.mov



