### PR TITLE
feat: title of the window changes as buffers are changed

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -15,6 +15,8 @@ local the_primeagen_harpoon = vim.api.nvim_create_augroup(
     { clear = true }
 )
 
+vim.cmd("set title titlestring=nvim\\ %t")
+
 vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
     callback = function()
         require("harpoon.mark").store_offset()


### PR DESCRIPTION
Before adding this line, when we started changing buffers with harpoon, the window title kept being the same as the first opened file. With this line, the title changes dynamically as we change buffers.