### PR TITLE
[fix] nvim_create_autocmd expects a table of events

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -15,7 +15,7 @@ local the_primeagen_harpoon = vim.api.nvim_create_augroup(
     { clear = true }
 )
 
-vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
+vim.api.nvim_create_autocmd({ "BufLeave", "VimLeave" }, {
     callback = function()
         require("harpoon.mark").store_offset()
     end,


### PR DESCRIPTION
Previous versions of neovim might have accepted a comma-separated list of events in a single string, but [it doesn't anymore](https://github.com/neovim/neovim/issues/17664#issuecomment-1072978649). I'm using v0.7.2 and the marks are not stored on "VimLeave" without this change (the autocommand is not listed in `:au VimLeave`).