### PR TITLE
Formatted failing files

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -10,10 +10,8 @@ local cache_config = string.format("%s/harpoon.json", data_path)
 
 local M = {}
 
-local the_primeagen_harpoon = vim.api.nvim_create_augroup(
-    "THE_PRIMEAGEN_HARPOON",
-    { clear = true }
-)
+local the_primeagen_harpoon =
+    vim.api.nvim_create_augroup("THE_PRIMEAGEN_HARPOON", { clear = true })
 
 vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
     callback = function()

--- a/lua/harpoon/tmux.lua
+++ b/lua/harpoon/tmux.lua
@@ -7,10 +7,8 @@ local M = {}
 local tmux_windows = {}
 
 if global_config.tmux_autoclose_windows then
-    local harpoon_tmux_group = vim.api.nvim_create_augroup(
-        "HARPOON_TMUX",
-        { clear = true }
-    )
+    local harpoon_tmux_group =
+        vim.api.nvim_create_augroup("HARPOON_TMUX", { clear = true })
 
     vim.api.nvim_create_autocmd("VimLeave", {
         callback = function()

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -38,16 +38,14 @@ function M.get_os_command_output(cmd, cwd)
     end
     local command = table.remove(cmd, 1)
     local stderr = {}
-    local stdout, ret = Job
-        :new({
-            command = command,
-            args = cmd,
-            cwd = cwd,
-            on_stderr = function(_, data)
-                table.insert(stderr, data)
-            end,
-        })
-        :sync()
+    local stdout, ret = Job:new({
+        command = command,
+        args = cmd,
+        cwd = cwd,
+        on_stderr = function(_, data)
+            table.insert(stderr, data)
+        end,
+    }):sync()
     return stdout, ret, stderr
 end
 


### PR DESCRIPTION
Fixes files in the master branch that were not formatted correctly. This caused the stylua format action to fail on every PR submitted, which at a glance could mislead maintainers to think it was the fault of the PR. Hopefully this will reduce the friction a bit for contribution.