### PR TITLE
Fix item before plenary.paths

### DIFF
--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -27,8 +27,15 @@ function M.branch_key()
     end
 end
 
+local function fixItem(item)
+    local upperItem = item:gsub('^%l:', string.upper)
+    local fixedItem = vim.fs.normalize(upperItem):gsub('/', '\\')
+    return fixedItem
+end
+
 function M.normalize_path(item)
-    return Path:new(item):make_relative(M.project_key())
+    local fixedItem = fixItem(item)
+    return Path:new(fixedItem):make_relative(M.project_key())
 end
 
 function M.get_os_command_output(cmd, cwd)


### PR DESCRIPTION
I was having a problem with harpoon on windows, somethimes for some reason vim.api.nvim_buf_get_name() gives the path of the directory with the partition letter undercase like "c:\\" or put / instead of \\, this things just breaks the plenary normalizer

I created this "solution" and it's working fine for me at the moment

If anyone can improve this code please doit, i'm realy new to Lua so this maybe can be something ugly or bad i don't no
