### PR TITLE
fix: do not force absolute file paths

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -173,11 +173,7 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local filename = mark.filename
-    if filename:sub(1, 1) ~= "/" then
-        filename = vim.loop.cwd() .. "/" .. mark.filename
-    end
-    local buf_id = get_or_create_buffer(filename)
+    local buf_id = get_or_create_buffer(mark.filename)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     vim.api.nvim_set_current_buf(buf_id)


### PR DESCRIPTION
When forcing absolute filepaths buffer names will get that absolute filepath too. To me it seems that vim.fn.bufadd supports relative paths just fine.