### PR TITLE
Performance improvements 

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -144,7 +144,7 @@ end
 
 local function read_config(local_config)
     log.trace("_read_config():", local_config)
-    return vim.fn.json_decode(Path:new(local_config):read())
+    return vim.json.decode(Path:new(local_config):read())
 end
 
 -- 1. saved.  Where do we save?

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -136,7 +136,7 @@ local function filter_filetype()
     end
 end
 
-function M.get_index_of(item)
+function M.get_index_of(item, marks)
     log.trace("get_index_of():", item)
     if item == nil then
         log.error(
@@ -150,8 +150,10 @@ function M.get_index_of(item)
 
     if type(item) == "string" then
         local relative_item = utils.normalize_path(item)
-        local marks = harpoon.get_mark_config().marks
-        for idx = 1, M.get_length() do
+        if marks == nil then
+            marks = harpoon.get_mark_config().marks
+        end
+        for idx = 1, M.get_length(marks) do
             if marks[idx] and marks[idx].filename == relative_item then
                 return idx
             end
@@ -191,13 +193,13 @@ function M.status(bufnr)
     return ""
 end
 
-function M.valid_index(idx)
+function M.valid_index(idx, marks)
     log.trace("valid_index():", idx)
     if idx == nil then
         return false
     end
 
-    local file_name = M.get_marked_file_name(idx)
+    local file_name = M.get_marked_file_name(idx, marks)
     return file_name ~= nil and file_name ~= ""
 end
 
@@ -246,9 +248,10 @@ end
 function M.store_offset()
     log.trace("store_offset()")
     local ok, res = pcall(function()
+        local marks = harpoon.get_mark_config().marks
         local buf_name = get_buf_name()
-        local idx = M.get_index_of(buf_name)
-        if not M.valid_index(idx) then
+        local idx = M.get_index_of(buf_name, marks)
+        if not M.valid_index(idx, marks) then
             return
         end
 
@@ -260,8 +263,8 @@ function M.store_offset()
                 cursor_pos[2]
             )
         )
-        harpoon.get_mark_config().marks[idx].row = cursor_pos[1]
-        harpoon.get_mark_config().marks[idx].col = cursor_pos[2]
+        marks[idx].row = cursor_pos[1]
+        marks[idx].col = cursor_pos[2]
     end)
 
     if not ok then
@@ -301,15 +304,23 @@ function M.get_marked_file(idxOrName)
     return harpoon.get_mark_config().marks[idxOrName]
 end
 
-function M.get_marked_file_name(idx)
-    local mark = harpoon.get_mark_config().marks[idx]
+function M.get_marked_file_name(idx, marks)
+    local mark
+    if marks ~= nil then
+        mark = marks[idx]
+    else
+        mark = harpoon.get_mark_config().marks[idx]
+    end
     log.trace("get_marked_file_name():", mark and mark.filename)
     return mark and mark.filename
 end
 
-function M.get_length()
+function M.get_length(marks)
+    if marks == nil then
+        marks = harpoon.get_mark_config().marks
+    end
     log.trace("get_length()")
-    return table.maxn(harpoon.get_mark_config().marks)
+    return table.maxn(marks)
 end
 
 function M.set_current_at(idx)

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -150,8 +150,9 @@ function M.get_index_of(item)
 
     if type(item) == "string" then
         local relative_item = utils.normalize_path(item)
+        local marks = harpoon.get_mark_config().marks
         for idx = 1, M.get_length() do
-            if M.get_marked_file_name(idx) == relative_item then
+            if marks[idx] and marks[idx].filename == relative_item then
                 return idx
             end
         end


### PR DESCRIPTION
I'm hoping to use this PR to make a few performance improvements.

The first commit is a minor performance improvement to speed up buffer switching. The culprit is [this call](https://github.com/ThePrimeagen/harpoon/blob/f4aff5bf9b512f5a85fe20eb1dcf4a87e512d971/lua/harpoon/init.lua#L20) to `store_offset()` which is setup as a `BufLeave` autocmd. It loops through all harpoon marks to find a match for the current buffer, and stores the cursor's row + column position for that mark, all before leaving the buffer. The more marks we add, the more marks we have to loop through when buffer switching. This commit moves the `get_mark_config()` call outside our loop which marginally improves buffer switching performance.

Will try to dig into other optimizations like a faster JSON parser or anything else I can find.

