### PR TITLE
normalize filename using vim.fs

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -173,10 +173,7 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local filename = mark.filename
-    if filename:sub(1, 1) ~= "/" then
-        filename = vim.loop.cwd() .. "/" .. mark.filename
-    end
+    local filename = vim.fs.normalize(mark.filename)
     local buf_id = get_or_create_buffer(filename)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 


### PR DESCRIPTION
This will fix the issues on Windows where the path is clobbered because a full path does not start with a '/'.

I tested this out by moving with `:cd  something` to different folders and then use harpoon to navigate to the files and that all worked fine both on Windows and Linux. 

I tried to apply the remarks given in https://github.com/ThePrimeagen/harpoon/pull/226 and https://github.com/ThePrimeagen/harpoon/pull/224 by using the new `vim.fs.normalize` function to regularize the filenames.

This should fix https://github.com/ThePrimeagen/harpoon/issues/234  and possibly others but it is hard to read some of these and be confident it is the same issue.
