### PR TITLE
Fix nil in index column for telescope extension

### DIFF
--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -7,10 +7,11 @@ local conf = require("telescope.config").values
 local harpoon = require("harpoon")
 local harpoon_mark = require("harpoon.mark")
 
-local function filter_empty_string(list)
+local function prepare_results(list)
     local next = {}
     for idx = 1, #list do
         if list[idx].filename ~= "" then
+            list[idx].index = idx
             table.insert(next, list[idx])
         end
     end
@@ -20,7 +21,7 @@ end
 
 local generate_new_finder = function()
     return finders.new_table({
-        results = filter_empty_string(harpoon.get_mark_config().marks),
+        results = prepare_results(harpoon.get_mark_config().marks),
         entry_maker = function(entry)
             local line = entry.filename .. ":" .. entry.row .. ":" .. entry.col
             local displayer = entry_display.create({


### PR DESCRIPTION
This PR updates the `telescope` extension's `results` and `entry_maker` config options. This resolves the issue where the mark/result/entry index is `nil` (see #242 ). In addition, it renames `filter_empty_string` to `prepare_results` to be more descriptive.

Before:
![image](https://user-images.githubusercontent.com/2755722/209355403-40531580-82b9-4cea-a584-83baa6e9b1de.png)


After:

<img width="1624" alt="Screenshot 2022-12-23 at 12 17 44 AM" src="https://user-images.githubusercontent.com/2755722/209276838-db156bfe-531d-4be8-9491-675595dae75f.png">
