### PR TITLE
Remove empty `[No Name]` buffer when navigating to file.

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -180,6 +180,8 @@ function M.nav_file(id)
     local buf_id = get_or_create_buffer(filename)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
+    local old_bufnr = vim.api.nvim_get_current_buf()
+
     vim.api.nvim_set_current_buf(buf_id)
     vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
     if set_row and mark.row and mark.col then
@@ -191,6 +193,14 @@ function M.nav_file(id)
                 mark.col
             )
         )
+    end
+
+    local old_bufinfo = vim.fn.getbufinfo(old_bufnr)[1]
+    local no_name = old_bufinfo.name == ""
+    local one_line = old_bufinfo.linecount == 1
+    local unchanged = old_bufinfo.changed == 0
+    if no_name and one_line and unchanged then
+        vim.api.nvim_buf_delete(old_bufnr, {})
     end
 end
 


### PR DESCRIPTION
I have an annoying experience every time I navigate to one of my harpoon files right after launching vim that roughly goes as follows:

- Launch vim (opens empty buffer)
![image](https://user-images.githubusercontent.com/28124404/213622654-0373c800-cff7-462f-90a7-fe9c8099cbfe.png)
- Navigate to first harpoon file (opens file, leaves empty buffer loaded)
![image](https://user-images.githubusercontent.com/28124404/213622743-acb53933-c7a4-4916-b9c2-efaa10e13f0b.png)
- Switch back to empty unnamed buffer
- Delete empty unnamed buffer
![image](https://user-images.githubusercontent.com/28124404/213622826-66ebc56d-c934-48a7-8989-9c2cd4a650c0.png)

This change addresses this issue by adding a few lines of code to check whether the current  buffer before navigating is an empty unnamed buffer and deletes it after navigation:

- Launch vim (opens empty buffer)
![image](https://user-images.githubusercontent.com/28124404/213622654-0373c800-cff7-462f-90a7-fe9c8099cbfe.png)
- Navigate to first harpoon file (opens file, deletes empty buffer)
![image](https://user-images.githubusercontent.com/28124404/213622826-66ebc56d-c934-48a7-8989-9c2cd4a650c0.png)