### PR TITLE
feat: Add option to show file keymaps

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,6 +6,7 @@ globals = {
     "HarpoonConfig",
     "Harpoon_bufh",
     "Harpoon_win_id",
+    "Harpoon_ns_id",
     "Harpoon_cmd_win_id",
     "Harpoon_cmd_bufh",
 }

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -54,6 +54,9 @@ vim.api.nvim_create_autocmd("FileType", {
         end, { buffer = true, noremap = true, silent = true })
     end,
 })
+
+vim.cmd("highlight default link HarpoonKeymap SpecialComment")
+
 --[[
 {
     projects = {
@@ -210,6 +213,8 @@ function M.setup(config)
             ["tmux_autoclose_windows"] = false,
             ["excluded_filetypes"] = { "harpoon" },
             ["mark_branch"] = false,
+            ["show_file_keymaps"] = false,
+            ["file_keymaps"] = { "h", "t", "n", "s" },
         },
     }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -76,16 +76,27 @@ local function show_file_keymaps(keymaps)
     for idx = 1, #keymaps do
         extmarks[idx] = {
             id = idx,
-            -- virt_text = {{ string.format("%s ", global_config.file_keymaps[idx]), "HarpoonKeymap" }},
+            -- virt_text = {{ string.format("%s ", keymaps[idx], "HarpoonKeymap" }},
             -- virt_text_pos = "right_align",
-            sign_text = string.format(" %s", keymaps[idx]),
+            sign_text = string.rep(" ", 2 - #keymaps[idx]) .. keymaps[idx],
             sign_hl_group = "HarpoonKeymap",
+        }
+    end
+    local num_extmarks = #extmarks
+    local function extmark_for_line_nr(line_nr)
+        local sign_text = string.format("%s", line_nr)
+        return {
+            id = line_nr,
+            -- virt_text = {{ string.format("%s ", idx, "LineNr" }},
+            -- virt_text_pos = "right_align",
+            sign_text = string.rep(" ", 2 - #sign_text) .. sign_text,
+            sign_hl_group = "LineNr",
         }
     end
     vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
         buffer = Harpoon_bufh,
         callback = function()
-            local num_lines = vim.call("line", "$")
+            local num_lines = vim.fn["line"]("$")
             for idx = 1, #extmarks do
                 if idx <= num_lines then
                     vim.api.nvim_buf_set_extmark(
@@ -103,10 +114,28 @@ local function show_file_keymaps(keymaps)
                     )
                 end
             end
+            for idx = #extmarks + 1, math.max(num_extmarks, num_lines) do
+                if idx <= num_lines then
+                    vim.api.nvim_buf_set_extmark(
+                        Harpoon_bufh,
+                        Harpoon_ns_id,
+                        idx - 1,
+                        0,
+                        extmark_for_line_nr(idx)
+                    )
+                else
+                    vim.api.nvim_buf_del_extmark(
+                        Harpoon_bufh,
+                        Harpoon_ns_id,
+                        idx
+                    )
+                end
+            end
+            num_extmarks = num_lines
         end,
     })
-    -- vim.api.nvim_win_set_option(Harpoon_win_id, "number", false)
-    -- vim.api.nvim_win_set_option(Harpoon_win_id, "signcolumn", "yes:2")
+    vim.api.nvim_win_set_option(Harpoon_win_id, "number", false)
+    vim.api.nvim_win_set_option(Harpoon_win_id, "signcolumn", "yes:2")
 end
 
 function M.toggle_quick_menu()


### PR DESCRIPTION
Sometimes I forget which key I have bound to each Harpoon file. This PR adds optional keymap hints, which can be enabled with the `show_file_keymaps` setting and customized with the `file_keymaps` setting.

<img width="444" alt="Screenshot 2023-02-01 at 1 53 32 AM" src="https://user-images.githubusercontent.com/7785912/215972472-2d1d2beb-a6cc-4686-9393-97228d6a99bf.png">

### Alternatives
The line numbers could be hidden for a cleaner look. I'm leaning towards this option, as showing the keymaps make the line numbers mostly redundant (you could add numbers to `file_keymaps` for additional lines).
<img width="440" alt="Screenshot 2023-02-01 at 1 55 27 AM" src="https://user-images.githubusercontent.com/7785912/215972751-1d569e03-f971-4e2c-b55a-6db2f9bcee75.png">

Or the keymaps could be right-aligned. This leaves more space for a full keymap hint, but I haven't gotten the behavior to work properly when long filenames overlap the hint.
<img width="446" alt="Screenshot 2023-02-01 at 12 59 25 AM" src="https://user-images.githubusercontent.com/7785912/215963725-14489aa8-d59e-4c8b-8e13-ce40da51837a.png">

### Update

Now shows line numbers for lines without keymaps:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/7785912/218797896-d0fefd75-c45c-4bbe-9cf6-61a64870b6fd.png">

### Limitations

- Because of how config settings are merged, it is hard to configure fewer than the default number of file keymaps, or reduce the number of keymaps below a previously defined value. (This requires editing the harpoon.json file while harpoon is not running.)