### PR TITLE
Nitpick: Changed the neovim logo to white 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ##### Getting you where you want with the fewest keystrokes.
 
 [![Lua](https://img.shields.io/badge/Lua-blue.svg?style=for-the-badge&logo=lua)](http://www.lua.org)
-[![Neovim](https://img.shields.io/badge/Neovim%200.5+-green.svg?style=for-the-badge&logo=neovim)](https://neovim.io)
+[![Neovim](https://img.shields.io/badge/Neovim%200.5+-green.svg?style=for-the-badge&logo=neovim&logoColor=white)](https://neovim.io)
 </div>
 
 ![Harpoon](harpoon.png)


### PR DESCRIPTION
I know it's nitpicky. If you would prefer the logo to be green i understand, its just a tad bit hard to see. 