### PR TITLE
Allow grep by mark number in telescope extension

### DIFF
--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -23,6 +23,7 @@ local generate_new_finder = function()
     return finders.new_table({
         results = prepare_results(harpoon.get_mark_config().marks),
         entry_maker = function(entry)
+            local ordinal = entry.index .. " - " .. entry.filename
             local line = entry.filename .. ":" .. entry.row .. ":" .. entry.col
             local displayer = entry_display.create({
                 separator = " - ",
@@ -34,13 +35,13 @@ local generate_new_finder = function()
             })
             local make_display = function()
                 return displayer({
-                    tostring(entry.index),
+                    { tostring(entry.index), "TelescopeResultsNumber" },
                     line,
                 })
             end
             return {
                 value = entry,
-                ordinal = line,
+                ordinal = ordinal,
                 display = make_display,
                 lnum = entry.row,
                 col = entry.col,


### PR DESCRIPTION
When I open harpoon's telescope picker and type the mark number, telescope does not pick that mark. Furthermore, if that number appears in the row/col numbers of another mark, telescope will pick the other mark instead!

I feel like searching for marks by their number is much more common than searching based on whatever row/col number was saved in harpoon.

This PR adds grep by mark number and removes grep by row/col number (due to conflicts with mark numbers). It also adds highlighting of mark numbers with TelescopeResultsNumber.