### PR TITLE
Use fugitive for faster branch name resolution

### DIFF
--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -11,14 +11,25 @@ function M.project_key()
 end
 
 function M.branch_key()
-    -- `git branch --show-current` requires Git v2.22.0+ so going with more
-    -- widely available command
-    local branch = M.get_os_command_output({
-        "git",
-        "rev-parse",
-        "--abbrev-ref",
-        "HEAD",
-    })[1]
+    local branch
+
+    -- use tpope's fugitive for faster branch name resolution if available
+    if vim.fn.exists("*FugitiveHead") == 1 then
+        branch = vim.fn["FugitiveHead"]()
+        -- return "HEAD" for parity with `git rev-parse` in detached head state
+        if #branch == 0 then
+            branch = "HEAD"
+        end
+    else
+        -- `git branch --show-current` requires Git v2.22.0+ so going with more
+        -- widely available command
+        branch = M.get_os_command_output({
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        })[1]
+    end
 
     if branch then
         return vim.loop.cwd() .. "-" .. branch


### PR DESCRIPTION
There's a noticeable slowdown when opening the quick menu or switching to a file when `mark_branch` is enabled. It's present even on modern hardware with a fast ssd. Barely noticeable but still enough to destroy that creamy-smooth harpoon feel.

I've identified the cause of the slowdown to be the call to the `git` binary when getting the branch name.

Given the ubiquity of tpope's `vim-fugitive`, I've used `FugitiveHead` to get the branch name. It doesn't rely on the `git` binary so it's noticeably faster.  It's not a hard dependency, so when fugitive is not available, it falls back to the current method - calling `git rev-parse`.