### PR TITLE
feat(term): adds function send the last used command again

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ further more commands can be stored for later quick
 lua require('harpoon.cmd-ui').toggle_quick_menu()       -- shows the commands menu
 lua require("harpoon.term").sendCommand(1, 1)           -- sends command 1 to term 1
 ```
+the last command you've selected with the cmd-ui's quick menu can be resent
+```lua
+lua require('harpoon.cmd-ui').resend()                  -- resends the last selected command to the last selected terminal
+```
 
 ### Tmux Support
 tmux is supported out of the box and can be used as a drop-in replacement to normal terminals

--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -9,6 +9,9 @@ local M = {}
 Harpoon_cmd_win_id = nil
 Harpoon_cmd_bufh = nil
 
+Harpoon_last_selected_cmd = nil
+Harpoon_last_selected_idx = nil
+
 local function close_menu(force_save)
     force_save = force_save or false
     local global_config = harpoon.get_global_settings()
@@ -141,6 +144,7 @@ end
 function M.select_menu_item()
     log.trace("cmd-ui#select_menu_item()")
     local cmd = vim.fn.line(".")
+    Harpoon_last_selected_cmd = cmd
     close_menu(true)
     local answer = vim.fn.input("Terminal index (default to 1): ")
     if answer == "" then
@@ -148,6 +152,7 @@ function M.select_menu_item()
     end
     local idx = tonumber(answer)
     if idx then
+        Harpoon_last_selected_idx = idx
         term.sendCommand(idx, cmd)
     end
 end
@@ -155,6 +160,21 @@ end
 function M.on_menu_save()
     log.trace("cmd-ui#on_menu_save()")
     term.set_cmd_list(get_menu_items())
+end
+
+function M.resend()
+    log.trace("cmd-ui#resend()")
+    if (Harpoon_last_selected_cmd == nil or Harpoon_last_selected_idx == nil) then
+        log.warn(
+            string.format(
+                "Could not resend command '%s' to term idx '%s' because at least one of them is nil.",
+                Harpoon_last_selected_cmd, Harpoon_last_selected_idx
+            )
+        )
+        return
+    end
+
+    term.sendCommand(Harpoon_last_selected_idx, Harpoon_last_selected_cmd)
 end
 
 return M


### PR DESCRIPTION
For the longest time I wasn't sure how to use this plugin's term feature, but I think I got it now.

The best way for me would be to use the cmd-ui to write out some command I am usually running in my current project and then map something like `<leader><CR>` to use `sendCommand(1, 1)`.

This PR would be the next logical step to enhance that, by not narrowing it to always use a specific command on a specific term handle.

```lua
require("cmd-ui").resend() -- resends the last command selected before
```

Maybe someone else thinks this could be helpful too!