### PR TITLE
fix(ui): save harpoon when save_on_change is false

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -134,7 +134,7 @@ function M.toggle_quick_menu()
     )
     vim.cmd(
         string.format(
-            "autocmd BufWriteCmd <buffer=%s> lua require('harpoon.ui').on_menu_save()",
+            "autocmd BufWriteCmd <buffer=%s> lua require('harpoon.ui').on_menu_save() require('harpoon').save()",
             Harpoon_bufh
         )
     )


### PR DESCRIPTION
If you don't want to save on each text change: (https://github.com/ThePrimeagen/harpoon/blob/21f4c47c6803d64ddb934a5b314dcb1b8e7365dc/lua/harpoon/ui.lua#L141-L148),
you need to put save_on_change to false. When save_on_change is false, the marks are never saved: https://github.com/ThePrimeagen/harpoon/blob/21f4c47c6803d64ddb934a5b314dcb1b8e7365dc/lua/harpoon/mark.lua#L17-L19