### PR TITLE
feat(ui)!: add config for saving the config for every change in the ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ global_settings = {
     -- saves the harpoon file upon every change. disabling is unrecommended.
     save_on_change = true,
 
+    -- saves the harpoon file upon every change in the ui.
+    save_on_text_change = false
+
     -- sets harpoon to run the command immediately as it's passed to the terminal when calling `sendCommand`.
     enter_on_sendcmd = false,
 

--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -122,7 +122,7 @@ function M.toggle_quick_menu()
             Harpoon_cmd_bufh
         )
     )
-    if global_config.save_on_change then
+    if global_config.save_on_text_change then
         vim.cmd(
             string.format(
                 "autocmd TextChanged,TextChangedI <buffer=%s> lua require('harpoon.cmd-ui').on_menu_save()",

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -206,6 +206,7 @@ function M.setup(config)
         global_settings = {
             ["save_on_toggle"] = false,
             ["save_on_change"] = true,
+            ["save_on_text_change"] = false,
             ["enter_on_sendcmd"] = false,
             ["tmux_autoclose_windows"] = false,
             ["excluded_filetypes"] = { "harpoon" },

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -138,7 +138,7 @@ function M.toggle_quick_menu()
             Harpoon_bufh
         )
     )
-    if global_config.save_on_change then
+    if global_config.save_on_text_change then
         vim.cmd(
             string.format(
                 "autocmd TextChanged,TextChangedI <buffer=%s> lua require('harpoon.ui').on_menu_save()",


### PR DESCRIPTION
There were different behaviour for `save_on_change` setting:
1. Autocmd to call `on_menu_save` for each text change in ui
2. Check if harpoon should save on emitting change (for instance add mark)

These two are different use-cases, and are now split into separate configs `save_on_change` and `save_on_text_change`.

BREAKING CHANGE: The default behaviour is set to `false`.