### PR TITLE
feat(tabline): added format function to export

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,3 @@
+{
+    "completion.autoRequire": false
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,4 @@
 {
-    "completion.autoRequire": false
+    "completion.autoRequire": false,
+    "workspace.checkThirdParty": false
 }

--- a/lua/harpoon/tabline.lua
+++ b/lua/harpoon/tabline.lua
@@ -30,8 +30,8 @@ local function shorten_filenames(filenames)
     return shortened
 end
 
-function M.setup(opts)
-    function _G.tabline()
+function M.format(opts)
+    return function()
         local tabs = shorten_filenames(require('harpoon').get_mark_config().marks)
         local tabline = ''
 
@@ -67,6 +67,11 @@ function M.setup(opts)
 
         return tabline
     end
+end
+
+function M.setup(opts)
+
+    vim.api.nvim_set_var('tabline', M.format(opts))
 
     vim.opt.showtabline = 2
 

--- a/lua/harpoon/tabline.lua
+++ b/lua/harpoon/tabline.lua
@@ -52,13 +52,13 @@ function M.format(opts)
 
             if is_current then
                 tabline = tabline ..
-                    '%#HarpoonNumberActive#' .. (opts.tabline_prefix or '   ') .. i .. ' %*' .. '%#HarpoonActive#'
+                    '%#HarpoonNumberActive#' .. (opts.tabline_prefix or '   ') .. i .. ' %#HarpoonActive#'
             else
                 tabline = tabline ..
-                    '%#HarpoonNumberInactive#' .. (opts.tabline_prefix or '   ') .. i .. ' %*' .. '%#HarpoonInactive#'
+                    '%#HarpoonNumberInactive#' .. (opts.tabline_prefix or '   ') .. i .. ' %#HarpoonInactive#'
             end
 
-            tabline = tabline .. label .. (opts.tabline_suffix or '   ') .. '%*'
+            tabline = tabline .. label .. (opts.tabline_suffix or '   ')
 
             if i < #tabs then
                 tabline = tabline .. '%T'


### PR DESCRIPTION
The function can be exported via M.format(opts). I also got rid of the global function, so my LSP is happy. The actual tabline string has been edited as well to work more smoothly with lualine.