### PR TITLE
Prevent saving UI configuration values to cache

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -171,7 +171,10 @@ function M.save()
     M.refresh_projects_b4update()
 
     log.trace("save(): Saving cache config to", cache_config)
-    Path:new(cache_config):write(vim.fn.json_encode(HarpoonConfig), "w")
+    local c_config = {
+        projects = HarpoonConfig.projects,
+    }
+    Path:new(cache_config):write(vim.fn.json_encode(c_config), "w")
 end
 
 local function read_config(local_config)


### PR DESCRIPTION
Saving the menu and global_setting configuration values to cache can be confusing. If you remove a setting from your configuration, the config cache retains the value of the setting you deleted.

An easy way to recreate the issue is to update some UI settings, restart neovim, remove those values, then restart neovim again.

1. 
```lua
    require("harpoon").setup {
      menu = {
        width = vim.api.nvim_win_get_width(0) - 10,
      },
      tabline = true,
      tabline_suffix = "!!!!",
      tabline_prefix = "!!!!",
    }
```

2. restart Neovim
3. `require("harpoon").setup {}`
4. restart Neovim

The settings from step one are still being applied. I'd expect the default settings to be in place when setup is called with no options.

So this branch prevents those values from being saved to cache.

I found this issue where someone mentions the same thing.
https://github.com/ThePrimeagen/harpoon/issues/47#issue-839774236