### PR TITLE
Tabline for Windows Fix

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -186,8 +186,15 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local filename = vim.fs.normalize(mark.filename)
-    local buf_id = get_or_create_buffer(filename)
+    local buf_id
+
+    if vim.fn.has('macunix') == 0 then
+        buf_id = get_or_create_buffer(mark.filename)
+    else
+        local filename = vim.fs.normalize(mark.filename)
+        buf_id = get_or_create_buffer(filename)
+    end
+
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
     local old_bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
This is more of a workaround than a fix, but it removes filename normalization if you are not on Mac or Linux. This allows new buffers to be loaded with Windows formatted filenames, which allows them to be detected by the Harpoon tabline