### PR TITLE
Run commands in another tmux window and return back

### DIFF
--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -3,6 +3,7 @@ local popup = require("plenary.popup")
 local utils = require("harpoon.utils")
 local log = require("harpoon.dev").log
 local term = require("harpoon.term")
+local tmux = require("harpoon.tmux")
 
 local M = {}
 
@@ -138,10 +139,18 @@ function M.toggle_quick_menu()
     )
 end
 
+
 function M.select_menu_item()
     log.trace("cmd-ui#select_menu_item()")
     local cmd = vim.fn.line(".")
     close_menu(true)
+
+    local config = harpoon.get_global_settings();
+    if config.send_commands_to_tmux_window then
+        tmux.runCommand(cmd)
+        return
+    end
+
     local answer = vim.fn.input("Terminal index (default to 1): ")
     if answer == "" then
         answer = "1"

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -213,6 +213,7 @@ function M.setup(config)
             ["tabline"] = false,
             ["tabline_suffix"] = "   ",
             ["tabline_prefix"] = "   ",
+            ["send_commands_to_tmux_window"] = false,
         },
     }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
 


### PR DESCRIPTION
Hi,
I saw this [video](https://www.youtube.com/watch?v=hJzqEAf2U4I) on @ThePrimeagen channel in which he was trying to run a command in another TMUX window which after exiting come's back automatically to his previous TMUX window (neovim/vim).

Even though that video was specific for cht.sh I had other cases where I wanted the same behavior. And I also wanted it to work with the existing harpoon command buffer.
i.e. you open the buffer with a key-bind select the command with j and k press enter, run the command in a new tmux window, wait for some input, and return back to the previous window.