### PR TITLE
fix: set 'number' local

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to go to the files you want.
 
 
 ## ⇁ Installation
-* neovim 0.5.0+ required
+* neovim 0.7.0+ required
 * install using your favorite plugin manager (`vim-plug` in this example)
 ```vim
 Plug 'nvim-lua/plenary.nvim' " don't forget to add this one if you don't have it yet!

--- a/lua/harpoon/cmd-ui.lua
+++ b/lua/harpoon/cmd-ui.lua
@@ -42,10 +42,10 @@ local function create_window()
         borderchars = borderchars,
     })
 
-    vim.api.nvim_win_set_option(
-        win.border.win_id,
+    vim.api.nvim_set_option_value(
         "winhl",
-        "Normal:HarpoonBorder"
+        "Normal:HarpoonBorder",
+        { win = win.border.win_id }
     )
 
     return {
@@ -89,12 +89,24 @@ function M.toggle_quick_menu()
         contents[idx] = cmd
     end
 
-    vim.api.nvim_win_set_option(Harpoon_cmd_win_id, "number", true)
+    vim.api.nvim_set_option_value("number", true, { win = Harpoon_cmd_win_id })
     vim.api.nvim_buf_set_name(Harpoon_cmd_bufh, "harpoon-cmd-menu")
     vim.api.nvim_buf_set_lines(Harpoon_cmd_bufh, 0, #contents, false, contents)
-    vim.api.nvim_buf_set_option(Harpoon_cmd_bufh, "filetype", "harpoon")
-    vim.api.nvim_buf_set_option(Harpoon_cmd_bufh, "buftype", "acwrite")
-    vim.api.nvim_buf_set_option(Harpoon_cmd_bufh, "bufhidden", "delete")
+    vim.api.nvim_set_option_value(
+        "filetype",
+        "harpoon",
+        { buf = Harpoon_cmd_bufh }
+    )
+    vim.api.nvim_set_option_value(
+        "buftype",
+        "acwrite",
+        { buf = Harpoon_cmd_bufh }
+    )
+    vim.api.nvim_set_option_value(
+        "bufhidden",
+        "delete",
+        { buf = Harpoon_cmd_bufh }
+    )
     vim.api.nvim_buf_set_keymap(
         Harpoon_cmd_bufh,
         "n",

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -10,10 +10,8 @@ local cache_config = string.format("%s/harpoon.json", data_path)
 
 local M = {}
 
-local the_primeagen_harpoon = vim.api.nvim_create_augroup(
-    "THE_PRIMEAGEN_HARPOON",
-    { clear = true }
-)
+local the_primeagen_harpoon =
+    vim.api.nvim_create_augroup("THE_PRIMEAGEN_HARPOON", { clear = true })
 
 vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
     callback = function()

--- a/lua/harpoon/tabline.lua
+++ b/lua/harpoon/tabline.lua
@@ -7,7 +7,6 @@ local function get_color(group, attr)
     return vim.fn.synIDattr(vim.fn.synIDtrans(vim.fn.hlID(group)), attr)
 end
 
-
 local function shorten_filenames(filenames)
     local shortened = {}
 
@@ -21,7 +20,10 @@ local function shorten_filenames(filenames)
         local name = vim.fn.fnamemodify(file.filename, ":t")
 
         if counts[name] == 1 then
-            table.insert(shortened, { filename = vim.fn.fnamemodify(name, ":t") })
+            table.insert(
+                shortened,
+                { filename = vim.fn.fnamemodify(name, ":t") }
+            )
         else
             table.insert(shortened, { filename = file.filename })
         end
@@ -32,10 +34,11 @@ end
 
 function M.setup(opts)
     function _G.tabline()
-        local tabs = shorten_filenames(require('harpoon').get_mark_config().marks)
-        local tabline = ''
+        local tabs =
+            shorten_filenames(require("harpoon").get_mark_config().marks)
+        local tabline = ""
 
-        local index = require('harpoon.mark').get_index_of(vim.fn.bufname())
+        local index = require("harpoon.mark").get_index_of(vim.fn.bufname())
 
         for i, tab in ipairs(tabs) do
             local is_current = i == index
@@ -49,19 +52,26 @@ function M.setup(opts)
                 label = tab.filename
             end
 
-
             if is_current then
-                tabline = tabline ..
-                    '%#HarpoonNumberActive#' .. (opts.tabline_prefix or '   ') .. i .. ' %*' .. '%#HarpoonActive#'
+                tabline = tabline
+                    .. "%#HarpoonNumberActive#"
+                    .. (opts.tabline_prefix or "   ")
+                    .. i
+                    .. " %*"
+                    .. "%#HarpoonActive#"
             else
-                tabline = tabline ..
-                    '%#HarpoonNumberInactive#' .. (opts.tabline_prefix or '   ') .. i .. ' %*' .. '%#HarpoonInactive#'
+                tabline = tabline
+                    .. "%#HarpoonNumberInactive#"
+                    .. (opts.tabline_prefix or "   ")
+                    .. i
+                    .. " %*"
+                    .. "%#HarpoonInactive#"
             end
 
-            tabline = tabline .. label .. (opts.tabline_suffix or '   ') .. '%*'
+            tabline = tabline .. label .. (opts.tabline_suffix or "   ") .. "%*"
 
             if i < #tabs then
-                tabline = tabline .. '%T'
+                tabline = tabline .. "%T"
             end
         end
 
@@ -70,19 +80,27 @@ function M.setup(opts)
 
     vim.opt.showtabline = 2
 
-    vim.o.tabline = '%!v:lua.tabline()'
+    vim.o.tabline = "%!v:lua.tabline()"
 
     vim.api.nvim_create_autocmd("ColorScheme", {
         group = vim.api.nvim_create_augroup("harpoon", { clear = true }),
         pattern = { "*" },
         callback = function()
-            local color = get_color('HarpoonActive', 'bg#')
+            local color = get_color("HarpoonActive", "bg#")
 
-            if (color == "" or color == nil) then
+            if color == "" or color == nil then
                 vim.api.nvim_set_hl(0, "HarpoonInactive", { link = "Tabline" })
                 vim.api.nvim_set_hl(0, "HarpoonActive", { link = "TablineSel" })
-                vim.api.nvim_set_hl(0, "HarpoonNumberActive", { link = "TablineSel" })
-                vim.api.nvim_set_hl(0, "HarpoonNumberInactive", { link = "Tabline" })
+                vim.api.nvim_set_hl(
+                    0,
+                    "HarpoonNumberActive",
+                    { link = "TablineSel" }
+                )
+                vim.api.nvim_set_hl(
+                    0,
+                    "HarpoonNumberInactive",
+                    { link = "Tabline" }
+                )
             end
         end,
     })

--- a/lua/harpoon/term.lua
+++ b/lua/harpoon/term.lua
@@ -24,7 +24,7 @@ local function create_terminal(create_with)
 
     -- Make sure the term buffer has "hidden" set so it doesn't get thrown
     -- away and cause an error
-    vim.api.nvim_buf_set_option(buf_id, "bufhidden", "hide")
+    vim.api.nvim_set_option_value("bufhidden", "hide", { buf = buf_id })
 
     -- Resets the buffer back to the old one
     vim.api.nvim_set_current_buf(current_id)

--- a/lua/harpoon/tmux.lua
+++ b/lua/harpoon/tmux.lua
@@ -7,10 +7,8 @@ local M = {}
 local tmux_windows = {}
 
 if global_config.tmux_autoclose_windows then
-    local harpoon_tmux_group = vim.api.nvim_create_augroup(
-        "HARPOON_TMUX",
-        { clear = true }
-    )
+    local harpoon_tmux_group =
+        vim.api.nvim_create_augroup("HARPOON_TMUX", { clear = true })
 
     vim.api.nvim_create_autocmd("VimLeave", {
         callback = function()

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -44,10 +44,10 @@ local function create_window()
         borderchars = borderchars,
     })
 
-    vim.api.nvim_win_set_option(
-        win.border.win_id,
+    vim.api.nvim_set_option_value(
         "winhl",
-        "Normal:HarpoonBorder"
+        "Normal:HarpoonBorder",
+        { win = win.border.win_id }
     )
 
     return {
@@ -105,12 +105,12 @@ function M.toggle_quick_menu()
         contents[idx] = string.format("%s", file)
     end
 
-    vim.api.nvim_win_set_option(Harpoon_win_id, "number", true)
+    vim.api.nvim_set_option_value("number", true, { win = Harpoon_win_id })
     vim.api.nvim_buf_set_name(Harpoon_bufh, "harpoon-menu")
     vim.api.nvim_buf_set_lines(Harpoon_bufh, 0, #contents, false, contents)
-    vim.api.nvim_buf_set_option(Harpoon_bufh, "filetype", "harpoon")
-    vim.api.nvim_buf_set_option(Harpoon_bufh, "buftype", "acwrite")
-    vim.api.nvim_buf_set_option(Harpoon_bufh, "bufhidden", "delete")
+    vim.api.nvim_set_option_value("filetype", "harpoon", { buf = Harpoon_bufh })
+    vim.api.nvim_set_option_value("buftype", "acwrite", { buf = Harpoon_bufh })
+    vim.api.nvim_set_option_value("bufhidden", "delete", { buf = Harpoon_bufh })
     vim.api.nvim_buf_set_keymap(
         Harpoon_bufh,
         "n",
@@ -193,7 +193,7 @@ function M.nav_file(id)
     local old_bufnr = vim.api.nvim_get_current_buf()
 
     vim.api.nvim_set_current_buf(buf_id)
-    vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
+    vim.api.nvim_buf_set_lines("buflisted", true, { buf = buf_id })
     if set_row and mark.row and mark.col then
         vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
         log.debug(

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -49,16 +49,14 @@ function M.get_os_command_output(cmd, cwd)
     end
     local command = table.remove(cmd, 1)
     local stderr = {}
-    local stdout, ret = Job
-        :new({
-            command = command,
-            args = cmd,
-            cwd = cwd,
-            on_stderr = function(_, data)
-                table.insert(stderr, data)
-            end,
-        })
-        :sync()
+    local stdout, ret = Job:new({
+        command = command,
+        args = cmd,
+        cwd = cwd,
+        on_stderr = function(_, data)
+            table.insert(stderr, data)
+        end,
+    }):sync()
     return stdout, ret, stderr
 end
 

--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -51,9 +51,8 @@ local generate_new_finder = function()
 end
 
 local delete_harpoon_mark = function(prompt_bufnr)
-    local confirmation = vim.fn.input(
-        string.format("Delete current mark(s)? [y/n]: ")
-    )
+    local confirmation =
+        vim.fn.input(string.format("Delete current mark(s)? [y/n]: "))
     if
         string.len(confirmation) == 0
         or string.sub(string.lower(confirmation), 0, 1) ~= "y"
@@ -114,21 +113,23 @@ end
 return function(opts)
     opts = opts or {}
 
-    pickers.new(opts, {
-        prompt_title = "harpoon marks",
-        finder = generate_new_finder(),
-        sorter = conf.generic_sorter(opts),
-        previewer = conf.grep_previewer(opts),
-        attach_mappings = function(_, map)
-            map("i", "<c-d>", delete_harpoon_mark)
-            map("n", "<c-d>", delete_harpoon_mark)
+    pickers
+        .new(opts, {
+            prompt_title = "harpoon marks",
+            finder = generate_new_finder(),
+            sorter = conf.generic_sorter(opts),
+            previewer = conf.grep_previewer(opts),
+            attach_mappings = function(_, map)
+                map("i", "<c-d>", delete_harpoon_mark)
+                map("n", "<c-d>", delete_harpoon_mark)
 
-            map("i", "<c-p>", move_mark_up)
-            map("n", "<c-p>", move_mark_up)
+                map("i", "<c-p>", move_mark_up)
+                map("n", "<c-p>", move_mark_up)
 
-            map("i", "<c-n>", move_mark_down)
-            map("n", "<c-n>", move_mark_down)
-            return true
-        end,
-    }):find()
+                map("i", "<c-n>", move_mark_down)
+                map("n", "<c-n>", move_mark_down)
+                return true
+            end,
+        })
+        :find()
 end


### PR DESCRIPTION
There are a few more changes here than I originally envisioned. The problem I wanted to solve is that when you open a file in a new window (e.g. C-v), it inherits the `number` option from the harpoon window. The easiest way to solve this problem is to replace the deprecated (in the next release, I'm building nvim from master) `nvim_win_set_option` with `nvim_set_option_value` (released in 7.0).

I then noticed that `nvim_buf_set_option` was also deprecated, so I replaced all `nvim_buf_set_option` and `nvim_win_set_option` with `nvim_set_option_value` and changed the minimum required neovim version in the README.

Finally, I run stylua.