### PR TITLE
fix: events no longer can be comma separated

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -15,7 +15,7 @@ local the_primeagen_harpoon = vim.api.nvim_create_augroup(
     { clear = true }
 )
 
-vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
+vim.api.nvim_create_autocmd({ "BufLeave", "VimLeave" }, {
     callback = function()
         require("harpoon.mark").store_offset()
     end,


### PR DESCRIPTION
After https://github.com/neovim/neovim/pull/25523 the comma separated events are not valid any more and will throw error