### PR TITLE
feat: update highlight groups

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -72,6 +72,8 @@ function HarpoonUI:_create_window()
     local _, popup_info = popup.create(bufnr, {
         title = "Harpoon",
         highlight = "HarpoonWindow",
+        borderhighlight = "HarpoonBorder",
+        titlehighlight = "HarpoonTitle",
         line = math.floor(((vim.o.lines - height) / 2) - 1),
         col = math.floor((vim.o.columns - width) / 2),
         minwidth = width,
@@ -85,7 +87,6 @@ function HarpoonUI:_create_window()
     self.win_id = win_id
     self.border_win_id = popup_info.border.win_id
     vim.api.nvim_win_set_option(win_id, "number", true)
-    vim.api.nvim_win_set_option(win_id, "winhl", "Normal:HarpoonBorder")
 
     return win_id, bufnr
 end


### PR DESCRIPTION
I checked out the `popup` implementation in `plenary.nvim` and was able to make the highlight groups work!
Here's a quick and ugly demo with the following code:
```
vim.api.nvim_set_hl(0, "HarpoonWindow", { fg = "#fff000", bg = "#ff00ff" })
vim.api.nvim_set_hl(0, "HarpoonBorder", { fg = "#ff0000", bg = "#000000" })
vim.api.nvim_set_hl(0, "HarpoonTitle", { fg = "#ffffff", bg = "#40d9ff" })
```
![image](https://github.com/ThePrimeagen/harpoon/assets/84108846/1b652e95-1105-47a6-996d-a838399c21a1)

This will close #355