### PR TITLE
feat: link harpoon highlights to default groups

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -38,6 +38,15 @@ function Harpoon:setup(partial_config)
     self.config = Config.merge_config(partial_config, self.config)
     self.ui:configure(self.config.settings)
 
+    local highlights = {
+        HarpoonWindow = { default = true, link = "NormalFloat" },
+        HarpoonBorder = { default = true, link = "FloatBorder" },
+        HarpoonTitle = { default = true, link = "FloatTitle" },
+    }
+    for k, v in pairs(highlights) do
+        vim.api.nvim_set_hl(0, k, v)
+    end
+
     ---TODO: should we go through every seen list and update its config?
 
     if self.hooks_setup == false then


### PR DESCRIPTION
Apparently this is what the cool plugin devs do :smiley:

Proof:
- [Telescope](https://github.com/nvim-telescope/telescope.nvim/blob/3f5f165447d797576206e3b9bd555ea8db85b6f2/plugin/telescope.lua#L94)
- [Lazy](https://github.com/folke/lazy.nvim/blob/96584866b9c5e998cbae300594d0ccfd0c464627/lua/lazy/view/colors.lua#L42)
- [Mason](https://github.com/williamboman/mason.nvim/blob/41e75af1f578e55ba050c863587cffde3556ffa6/lua/mason/ui/colors.lua#L27)
- [Neogit](https://github.com/NeogitOrg/neogit/blob/d0e87541130b2cf62d7f8a54487ef99560232fb6/lua/neogit/lib/hl.lua#L204)