### PR TITLE
fix(buffer.lua): use double escape characters

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -45,21 +45,21 @@ function M.setup_autocmds_and_keymaps(bufnr)
         bufnr,
         "n",
         "q",
-        "<Cmd>lua require('harpoon').logger:log('toggle by keymap \'q\''); require('harpoon').ui:toggle_quick_menu()<CR>",
+        "<Cmd>lua require('harpoon').logger:log('toggle by keymap \\'q\\''); require('harpoon').ui:toggle_quick_menu()<CR>",
         { silent = true }
     )
     vim.api.nvim_buf_set_keymap(
         bufnr,
         "n",
         "<ESC>",
-        "<Cmd>lua require('harpoon').logger:log('toggle by keymap \'<Esc>\''); require('harpoon').ui:toggle_quick_menu()<CR>",
+        "<Cmd>lua require('harpoon').logger:log('toggle by keymap \\'<Esc>\\''); require('harpoon').ui:toggle_quick_menu()<CR>",
         { silent = true }
     )
     vim.api.nvim_buf_set_keymap(
         bufnr,
         "n",
         "<CR>",
-        "<Cmd>lua require('harpoon').logger:log('select by keymap \'<CR>\''); require('harpoon').ui:select_menu_item()<CR>",
+        "<Cmd>lua require('harpoon').logger:log('select by keymap \\'<CR>\\''); require('harpoon').ui:select_menu_item()<CR>",
         {}
     )
 


### PR DESCRIPTION
While pressing "q", I received the following error:

`E5107: Error loading lua [string ":lua"]:1: ')' expected near 'q'`