### PR TITLE
Remove `ui:toggle_quick_menu` from BufLeave autocmd

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -110,7 +110,6 @@ function M.setup_autocmds_and_keymaps(bufnr)
         pattern = "__harpoon*",
         callback = function()
             require("harpoon").logger:log("toggle by BufLeave")
-            require("harpoon").ui:toggle_quick_menu()
         end,
     })
 end


### PR DESCRIPTION
I don't know what that line is for, but removing it fixes some issues.