### PR TITLE
fix nav issues with q and escape

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -24,6 +24,10 @@ end
 function M.run_toggle_command(key)
     local harpoon = require("harpoon")
     harpoon.logger:log("toggle by keymap '" .. key .. "'")
+    if key == 'q' or key == '<Esc>' then
+        harpoon.ui:close_menu()
+        return
+    end
     harpoon.ui:select_menu_item()
 end
 
@@ -59,11 +63,12 @@ function M.setup_autocmds_and_keymaps(bufnr)
         "<Cmd>lua require('harpoon.buffer').run_toggle_command('q')<CR>",
         { silent = true }
     )
+    -- For some reason, even if mapped to escape, this comes through as <CR>, so will nav
     vim.api.nvim_buf_set_keymap(
         bufnr,
         "n",
         "<ESC>",
-        "<Cmd>lua require('harpoon.buffer').run_toggle_command('<ESC>')<CR>",
+        "<Cmd>lua require('harpoon').ui:close_menu()<CR>",
         { silent = true }
     )
     vim.api.nvim_buf_set_keymap(

--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -24,11 +24,10 @@ end
 function M.run_toggle_command(key)
     local harpoon = require("harpoon")
     harpoon.logger:log("toggle by keymap '" .. key .. "'")
-    if key == 'q' or key == '<Esc>' then
+    if key == 'q' or key == 'Esc' then
         harpoon.ui:close_menu()
         return
     end
-    harpoon.ui:select_menu_item()
 end
 
 ---TODO: I don't know how to do what i want to do, but i want to be able to
@@ -63,12 +62,12 @@ function M.setup_autocmds_and_keymaps(bufnr)
         "<Cmd>lua require('harpoon.buffer').run_toggle_command('q')<CR>",
         { silent = true }
     )
-    -- For some reason, even if mapped to escape, this comes through as <CR>, so will nav
+    -- For some reason, even if mapped to <Esc>, this comes through as <CR>, so Esc it is
     vim.api.nvim_buf_set_keymap(
         bufnr,
         "n",
         "<ESC>",
-        "<Cmd>lua require('harpoon').ui:close_menu()<CR>",
+        "<Cmd>lua require('harpoon.buffer').run_toggle_command('Esc')<CR>",
         { silent = true }
     )
     vim.api.nvim_buf_set_keymap(


### PR DESCRIPTION
This resolves #379 

I dont like the fix for escape, as it wouldn't save changes to the list
but in the logs, it would always come through a <CR> rather than an escape, not sure why.

Although, thinking about it, is Esc more of a cancel action then a save action
Open to thoughts