### PR TITLE
Add feature to disable/enable wrapping on next/prev when cycling through harpoon lists.

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -74,6 +74,7 @@ function M.get_default_config()
         },
 
         default = {
+            harpoon_wrap = true,
             --- select_with_nill allows for a list to call select even if the provided item is nil
             select_with_nil = false,
 

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -74,7 +74,9 @@ function M.get_default_config()
         },
 
         default = {
-            harpoon_wrap = true,
+            --- ui_nav_wrap allows the ability to enable(true) or disable(false) wrapping on prev and next list calls.
+            ui_nav_wrap = true,
+
             --- select_with_nill allows for a list to call select even if the provided item is nil
             select_with_nil = false,
 

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -171,7 +171,6 @@ end
 
 function HarpoonList:next()
     self._index = self._index + 1
-    print(self._index)
     if self._index > #self.items and self.config.harpoon_wrap then
         self._index = 1
     elseif self._index > #self.items and not self.config.harpoon_wrap then
@@ -183,7 +182,6 @@ end
 
 function HarpoonList:prev()
     self._index = self._index - 1
-    print(self._index)
     if self._index < 1 and self.config.harpoon_wrap then
         self._index = #self.items
     elseif self._index < 1 and not self.config.harpoon_wrap then

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -171,8 +171,11 @@ end
 
 function HarpoonList:next()
     self._index = self._index + 1
-    if self._index > #self.items then
+    print(self._index)
+    if self._index > #self.items and self.config.harpoon_wrap then
         self._index = 1
+    elseif self._index > #self.items and not self.config.harpoon_wrap then
+        self._index = #self.items
     end
 
     self:select(self._index)
@@ -180,8 +183,11 @@ end
 
 function HarpoonList:prev()
     self._index = self._index - 1
-    if self._index < 1 then
+    print(self._index)
+    if self._index < 1 and self.config.harpoon_wrap then
         self._index = #self.items
+    elseif self._index < 1 and not self.config.harpoon_wrap then
+        self._index = 1
     end
 
     self:select(self._index)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -171,9 +171,9 @@ end
 
 function HarpoonList:next()
     self._index = self._index + 1
-    if self._index > #self.items and self.config.harpoon_wrap then
+    if self._index > #self.items and self.config.ui_nav_wrap then
         self._index = 1
-    elseif self._index > #self.items and not self.config.harpoon_wrap then
+    elseif self._index > #self.items and not self.config.ui_nav_wrap then
         self._index = #self.items
     end
 
@@ -182,9 +182,9 @@ end
 
 function HarpoonList:prev()
     self._index = self._index - 1
-    if self._index < 1 and self.config.harpoon_wrap then
+    if self._index < 1 and self.config.ui_nav_wrap then
         self._index = #self.items
-    elseif self._index < 1 and not self.config.harpoon_wrap then
+    elseif self._index < 1 and not self.config.ui_nav_wrap then
         self._index = 1
     end
 

--- a/lua/harpoon/test/logger_spec.lua
+++ b/lua/harpoon/test/logger_spec.lua
@@ -1,4 +1,4 @@
-local utils = require("harpoon.test.utils")
+--local utils = require("harpoon.test.utils")
 local Logger = require("harpoon.logger")
 
 local eq = assert.are.same

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.trim(str)
-   return str:gsub("^%s+", ""):gsub("%s+$", "")
+    return str:gsub("^%s+", ""):gsub("%s+$", "")
 end
 function M.remove_duplicate_whitespace(str)
     return str:gsub("%s+", " ")
@@ -11,8 +11,8 @@ function M.split(str, sep)
     if sep == nil then
         sep = "%s"
     end
-    local t={}
-    for s in string.gmatch(str, "([^"..sep.."]+)") do
+    local t = {}
+    for s in string.gmatch(str, "([^" .. sep .. "]+)") do
         table.insert(t, s)
     end
     return t


### PR DESCRIPTION
Implements the ask on #341. Allows for people to configure the usage of harpoon_wrap in harpoon:setup(). By default harpoon_wrap is True which keeps the wrapping behavior that already existed.