### PR TITLE
fix: verify if self.bufnr is not nil before save

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -110,7 +110,7 @@ function HarpoonUI:toggle_quick_menu(list)
 
     if list == nil or self.win_id ~= nil then
         Logger:log("ui#toggle_quick_menu#closing", list and list.name)
-        if self.settings.save_on_toggle then
+        if self.settings.save_on_toggle and self.bufnr then
             self:save()
         end
         self:close_menu()


### PR DESCRIPTION
I reproduce the error and see that when you don't change the ui Harpoon try to save but buffer number don't exist, so this cause an error.

Issue: https://github.com/ThePrimeagen/harpoon/issues/385