### PR TITLE
fix(ui): comprehensive UI and sync fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Settings can alter the experience of harpoon
 **Definition**
 ```lua
 ---@class HarpoonSettings
----@field save_on_toggle boolean defaults to true
+---@field save_on_toggle boolean defaults to false
+---@field sync_on_ui_close boolean defaults to false
 ---@field key (fun(): string)
 
 ```
@@ -184,6 +185,7 @@ Settings can alter the experience of harpoon
 ```lua
 settings = {
     save_on_toggle = false,
+    sync_on_ui_close = false,
     border_chars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     key = function()
         return vim.loop.cwd()

--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -24,7 +24,7 @@ end
 function M.run_toggle_command(key)
     local harpoon = require("harpoon")
     harpoon.logger:log("toggle by keymap '" .. key .. "'")
-    harpoon.ui:select_menu_item()
+    harpoon.ui:toggle_quick_menu()
 end
 
 ---TODO: I don't know how to do what i want to do, but i want to be able to
@@ -63,7 +63,7 @@ function M.setup_autocmds_and_keymaps(bufnr)
         bufnr,
         "n",
         "<ESC>",
-        "<Cmd>lua require('harpoon.buffer').run_toggle_command('<ESC>')<CR>",
+        "<Cmd>lua require('harpoon.buffer').run_toggle_command('Esc')<CR>",
         { silent = true }
     )
     vim.api.nvim_buf_set_keymap(
@@ -86,16 +86,17 @@ function M.setup_autocmds_and_keymaps(bufnr)
         )
     end
     --]]
-    vim.cmd(
-        string.format(
-            "autocmd BufModifiedSet <buffer=%s> set nomodified",
-            bufnr
-        )
-    )
+    vim.api.nvim_create_autocmd("BufModifiedSet", {
+        buffer = bufnr,
+        group = HarpoonGroup,
+        callback = function()
+            vim.api.nvim_buf_set_option(bufnr, "modified", false)
+        end,
+    })
 
     vim.api.nvim_create_autocmd({ "BufWriteCmd" }, {
         group = HarpoonGroup,
-        pattern = "__harpoon*",
+        buffer = bufnr,
         callback = function()
             require("harpoon").ui:save()
             vim.schedule(function()
@@ -107,7 +108,7 @@ function M.setup_autocmds_and_keymaps(bufnr)
 
     vim.api.nvim_create_autocmd({ "BufLeave" }, {
         group = HarpoonGroup,
-        pattern = "__harpoon*",
+        buffer = bufnr,
         callback = function()
             require("harpoon").logger:log("toggle by BufLeave")
             require("harpoon").ui:toggle_quick_menu()

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -117,6 +117,10 @@ function M.get_default_config()
                     set_position = true
                     bufnr = vim.fn.bufnr(list_item.value, true)
                 end
+                if not vim.api.nvim_buf_is_loaded(bufnr) then
+                    vim.fn.bufload(bufnr)
+                    vim.api.nvim_buf_set_option(bufnr, "buflisted", true)
+                end
 
                 if options.vsplit then
                     vim.cmd("vsplit")

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -27,12 +27,14 @@ M.DEFAULT_LIST = DEFAULT_LIST
 ---@class HarpoonSettings
 ---@field border_chars string[] defaults to { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
 ---@field save_on_toggle boolean defaults to true
+---@field sync_on_ui_close? boolean
 ---@field ui_fallback_width number defaults 69, nice
 ---@field ui_width_ratio number defaults to 0.62569
 ---@field key (fun(): string)
 
 ---@class HarpoonPartialSettings
 ---@field save_on_toggle? boolean
+---@field sync_on_ui_close? boolean
 ---@field key? (fun(): string)
 
 ---@class HarpoonConfig
@@ -56,6 +58,7 @@ function M.get_default_config()
 
         settings = {
             save_on_toggle = false,
+            sync_on_ui_close = false,
             border_chars = {
                 "─",
                 "│",

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -51,6 +51,10 @@ function Harpoon:list(name)
     local existing_list = lists[name]
 
     if existing_list then
+        if not self.data.seen[key] then
+            self.data.seen[key] = {}
+        end
+        self.data.seen[key][name] = true
         return existing_list
     end
 

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -158,8 +158,6 @@ function HarpoonList:resolve_displayed(displayed)
     end
 
     self.items = new_list
-
-    require("harpoon"):sync()
 end
 
 function HarpoonList:select(index, options)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -129,11 +129,11 @@ function HarpoonList:resolve_displayed(displayed)
     local list_displayed = self:display()
 
     for i, v in ipairs(list_displayed) do
-        local index = index_of(list_displayed, v)
+        local index = index_of(displayed, v)
         if index == -1 then
             Listeners.listeners:emit(
                 Listeners.event_names.REMOVE,
-                { list = self, item = v, idx = i }
+                { list = self, item = self.items[i], idx = i }
             )
         end
     end
@@ -141,11 +141,11 @@ function HarpoonList:resolve_displayed(displayed)
     for i, v in ipairs(displayed) do
         local index = index_of(list_displayed, v)
         if index == -1 then
+            new_list[i] = self.config.create_list_item(self.config, v)
             Listeners.listeners:emit(
                 Listeners.event_names.ADD,
-                { list = self, item = v, idx = i }
+                { list = self, item = new_list[i], idx = i }
             )
-            new_list[i] = self.config.create_list_item(self.config, v)
         else
             local index_in_new_list =
                 index_of(new_list, self.items[index], self.config)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -99,12 +99,14 @@ end
 
 ---@return HarpoonList
 function HarpoonList:removeAt(index)
-    Listeners.listeners:emit(
-        Listeners.event_names.REMOVE,
-        { list = self, item = self.items[index], idx = index }
-    )
-    Logger:log("HarpoonList:removeAt", { item = self.items[index], index = index })
-    table.remove(self.items, index)
+    if self.items[index] then
+        Logger:log("HarpoonList:removeAt", { item = self.items[index], index = index })
+        Listeners.listeners:emit(
+            Listeners.event_names.REMOVE,
+            { list = self, item = self.items[index], idx = index }
+        )
+        table.remove(self.items, index)
+    end
     return self
 end
 

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -156,6 +156,8 @@ function HarpoonList:resolve_displayed(displayed)
     end
 
     self.items = new_list
+
+    require("harpoon"):sync()
 end
 
 function HarpoonList:select(index, options)

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -153,7 +153,6 @@ function HarpoonUI:save()
     local list = Buffer.get_contents(self.bufnr)
     Logger:log("ui#save", list)
     self.active_list:resolve_displayed(list)
-    require("harpoon"):sync()
 end
 
 ---@param settings HarpoonSettings

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -153,6 +153,9 @@ function HarpoonUI:save()
     local list = Buffer.get_contents(self.bufnr)
     Logger:log("ui#save", list)
     self.active_list:resolve_displayed(list)
+    if self.settings.sync_on_ui_close then
+        require("harpoon"):sync()
+    end
 end
 
 ---@param settings HarpoonSettings

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -107,7 +107,6 @@ end
 
 ---@param list? HarpoonList
 function HarpoonUI:toggle_quick_menu(list)
-
     if list == nil or self.win_id ~= nil then
         Logger:log("ui#toggle_quick_menu#closing", list and list.name)
         if self.settings.save_on_toggle then
@@ -154,6 +153,7 @@ function HarpoonUI:save()
     local list = Buffer.get_contents(self.bufnr)
     Logger:log("ui#save", list)
     self.active_list:resolve_displayed(list)
+    require("harpoon"):sync()
 end
 
 ---@param settings HarpoonSettings


### PR DESCRIPTION
These maybe should have been separate PRs, but they're all small changes and somewhat related so I made them all at once. If you want me to split this up, let me know. There are also some overlapping changes with #386, so I can remove that functionality from this PR if that one is preferred.

- fix: ensure buf is loaded on select (#383, #377)
- fix: remove angle brackets from Escape mapping rhs (#379, #385)
- fix: incorrect function call in run_toggle_command (#379)
- fix: use buf-local autocmds
- refactor: use Lua API to create BufModifiedSet autocmd
- fix: sync when list is resolved (mentioned in #386)
- fix: check displayed list to find removed items in `HarpoonList:resolve_displayed()` (fixes remove events not being dispatched when saving from the menu)
- fix: pass item objects to events in `HarpoonList:resolve_displayed()` instead of filenames (they're passed as objects in other places)
- fix: only emit event from `HarpoonList:removeAt()` if an item is actually removed

fixes #383, #385, #379, #377, #358
resolves #391, #386