### PR TITLE
feat: highlight the current file in the menu

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -32,18 +32,6 @@ end
 ---strings back into the ui.  it feels gross and it puts odd coupling
 ---@param bufnr number
 function M.setup_autocmds_and_keymaps(bufnr)
-    local curr_file = vim.api.nvim_buf_get_name(0)
-    local cmd = string.format(
-        "autocmd Filetype harpoon "
-            .. "let path = '%s' | call clearmatches() | "
-            -- move the cursor to the line containing the current filename
-            .. "call search('\\V'.path.'\\$') | "
-            -- add a hl group to that line
-            .. "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
-        curr_file:gsub("\\", "\\\\")
-    )
-    vim.cmd(cmd)
-
     if vim.api.nvim_buf_get_name(bufnr) == "" then
         vim.api.nvim_buf_set_name(bufnr, get_harpoon_menu_name())
     end

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -1,4 +1,5 @@
 local popup = require("plenary").popup
+local Path = require("plenary.path")
 local Buffer = require("harpoon.buffer")
 local Logger = require("harpoon.logger")
 
@@ -117,6 +118,9 @@ function HarpoonUI:toggle_quick_menu(list)
         return
     end
 
+    local current_buf =
+        vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
+
     Logger:log("ui#toggle_quick_menu#opening", list and list.name)
     local win_id, bufnr = self:_create_window()
 
@@ -126,6 +130,21 @@ function HarpoonUI:toggle_quick_menu(list)
 
     local contents = self.active_list:display()
     vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, contents)
+
+    -- Highlight the current file
+    for line, file in pairs(contents) do
+        if Path:new(file):absolute() == current_buf then
+            vim.api.nvim_buf_add_highlight(
+                bufnr,
+                -1,
+                "HarpoonCurrentFile",
+                line - 1,
+                0,
+                -1
+            )
+            break
+        end
+    end
 end
 
 ---@param options? any


### PR DESCRIPTION
Adds highlighting to the current file in the menu, and removes the old `matchadd` method of doing so which did not work. 

fixes #384 