### PR TITLE
feat: introduce move event

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -147,6 +147,12 @@ function HarpoonList:resolve_displayed(displayed)
             )
             new_list[i] = self.config.create_list_item(self.config, v)
         else
+            if index ~= i then
+                Listeners.listeners:emit(
+                    Listeners.event_names.REORDER,
+                    { list = self, item = self.items[index], idx = i }
+                )
+            end
             local index_in_new_list =
                 index_of(new_list, self.items[index], self.config)
             if index_in_new_list == -1 then

--- a/lua/harpoon/listeners.lua
+++ b/lua/harpoon/listeners.lua
@@ -52,5 +52,6 @@ return {
         ADD = "ADD",
         SELECT = "SELECT",
         REMOVE = "REMOVE",
+        REORDER = "REORDER",
     },
 }


### PR DESCRIPTION
Anotha one

Adds a `move` event so we can have similar tracking to v1's `harpoon.on("changed", ...)`. I use the event to trigger reordering of buffers in my tabline according to their order in harpoon (falling back to standard buffer order for non-marked bufs).