### PR TITLE
fix: remove deprecated api

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -48,9 +48,9 @@ function M.setup_autocmds_and_keymaps(bufnr)
         vim.api.nvim_buf_set_name(bufnr, get_harpoon_menu_name())
     end
 
-    vim.api.nvim_buf_set_option(bufnr, "filetype", "harpoon")
-    vim.api.nvim_buf_set_option(bufnr, "buftype", "acwrite")
-    vim.api.nvim_buf_set_option(bufnr, "bufhidden", "delete")
+    vim.api.nvim_set_option_value("filetype", "harpoon", { buf = bufnr })
+    vim.api.nvim_set_option_value("buftype", "acwrite", { buf = bufnr })
+    vim.api.nvim_set_option_value("bufhidden", "delete", { buf = bufnr })
 
     vim.api.nvim_buf_set_keymap(
         bufnr,


### PR DESCRIPTION
fixes an issue where after removal of plenary you can no longer write manually modified harpoon buffers

buf_set_option is deprecated

https://neovim.io/doc/user/deprecated.html