### PR TITLE
fix: restore acwrite

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -45,7 +45,8 @@ function M.setup_autocmds_and_keymaps(bufnr)
         vim.api.nvim_buf_set_name(bufnr, get_harpoon_menu_name())
     end
 
-    vim.api.nvim_buf_set_option(bufnr, "filetype", "harpoon")
+    vim.api.nvim_set_option_value("filetype", "harpoon", { buf = bufnr })
+    vim.api.nvim_set_option_value("buftype", "acwrite", { buf = bufnr })
     vim.keymap.set("n", "q", function()
         M.run_toggle_command("q")
     end, { buffer = bufnr, silent = true })


### PR DESCRIPTION
add definition of acwrite, this allows modifying and :w'ing the harpoon buffer

additionally, gets rid of a deprecated API call
https://neovim.io/doc/user/deprecated.html