### PR TITLE
refactor: remove uses of deprecated `buf_set_option`

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -45,7 +45,9 @@ function M.setup_autocmds_and_keymaps(bufnr)
         vim.api.nvim_buf_set_name(bufnr, get_harpoon_menu_name())
     end
 
-    vim.api.nvim_buf_set_option(bufnr, "filetype", "harpoon")
+    vim.api.nvim_set_option_value("filetype", "harpoon", {
+        buf = bufnr,
+    })
     vim.keymap.set("n", "q", function()
         M.run_toggle_command("q")
     end, { buffer = bufnr, silent = true })

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -114,7 +114,9 @@ function M.get_default_config()
                 end
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
                     vim.fn.bufload(bufnr)
-                    vim.api.nvim_buf_set_option(bufnr, "buflisted", true)
+                    vim.api.nvim_set_option_value("buflisted", true, {
+                        buf = bufnr,
+                    })
                 end
 
                 if options.vsplit then

--- a/lua/harpoon/test/utils.lua
+++ b/lua/harpoon/test/utils.lua
@@ -55,7 +55,9 @@ end
 ---@param contents string[]
 function M.create_file(name, contents, row, col)
     local bufnr = vim.fn.bufnr(name, true)
-    vim.api.nvim_buf_set_option(bufnr, "bufhidden", "hide")
+    vim.api.nvim_set_option_value("bufhidden", "hide", {
+        buf = bufnr,
+    })
     vim.api.nvim_set_current_buf(bufnr)
     vim.api.nvim_buf_set_text(0, 0, 0, 0, 0, contents)
     if row then

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -97,7 +97,9 @@ function HarpoonUI:_create_window(toggle_opts)
     Buffer.setup_autocmds_and_keymaps(bufnr)
 
     self.win_id = win_id
-    vim.api.nvim_win_set_option(win_id, "number", true)
+    vim.api.nvim_set_option_value("number", true, {
+        win = win_id
+    })
 
     Listeners.listeners:emit(Listeners.event_names.UI_CREATE, {
         win_id = win_id,


### PR DESCRIPTION
Replaces uses of `nvim_buf_set_option`, which is deprecated, with `nvim_set_option_value`