### PR TITLE
feat: add ui border and title pos. settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ Settings can alter the experience of harpoon
 ---@class HarpoonSettings
 ---@field save_on_toggle boolean defaults to false
 ---@field sync_on_ui_close boolean defaults to false
+---@field border string | string[8] defaults to "single"
+---@field title_pos "center" | "left" | "right" defaults to "center"
 ---@field key (fun(): string)
-
 ```
 
 **Descriptions**
@@ -186,6 +187,8 @@ Settings can alter the experience of harpoon
 settings = {
     save_on_toggle = false,
     sync_on_ui_close = false,
+    border = "single",
+    title_pos = "center"
     key = function()
         return vim.loop.cwd()
     end,

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -29,6 +29,8 @@ M.DEFAULT_LIST = DEFAULT_LIST
 ---@field sync_on_ui_close? boolean
 ---@field ui_fallback_width number defaults 69, nice
 ---@field ui_width_ratio number defaults to 0.62569
+---@field ui_border string | string[] defaults to "single"
+---@field ui_title_pos string defaults to "center"
 ---@field key (fun(): string)
 
 ---@class HarpoonPartialSettings
@@ -60,6 +62,8 @@ function M.get_default_config()
             sync_on_ui_close = false,
             ui_fallback_width = 69,
             ui_width_ratio = 0.62569,
+            ui_border = "single",
+            ui_title_pos = "center",
             key = function()
                 return vim.loop.cwd()
             end,

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -3,6 +3,8 @@ local Logger = require("harpoon.logger")
 local Listeners = require("harpoon.listeners")
 
 ---@class HarpoonToggleOptions
+---@field border string | string[]
+---@field title_pos "center" | "left" | "right"
 ---TODO: Finish.
 
 ---@class HarpoonUI
@@ -62,8 +64,6 @@ function HarpoonUI:close_menu()
     self.closing = false
 end
 
---- TODO: Toggle_opts should be where we get extra style and border options
---- and we should create a nice minimum window
 ---@param toggle_opts HarpoonToggleOptions
 ---@return number,number
 function HarpoonUI:_create_window(toggle_opts)
@@ -86,11 +86,14 @@ function HarpoonUI:_create_window(toggle_opts)
         width = width,
         height = height,
         style = "minimal",
-        border = "single",
+        border = toggle_opts.border or self.settings.ui_border,
+        title_pos = toggle_opts.title_pos or self.settings.ui_title_pos,
     })
 
     if win_id == 0 then
-        Logger:log("ui#_create_window failed to create window, win_id returned 0")
+        Logger:log(
+            "ui#_create_window failed to create window, win_id returned 0"
+        )
         error("Failed to create window")
     end
 
@@ -98,7 +101,7 @@ function HarpoonUI:_create_window(toggle_opts)
 
     self.win_id = win_id
     vim.api.nvim_set_option_value("number", true, {
-        win = win_id
+        win = win_id,
     })
 
     Listeners.listeners:emit(Listeners.event_names.UI_CREATE, {
@@ -110,8 +113,8 @@ function HarpoonUI:_create_window(toggle_opts)
 end
 
 ---@param list? HarpoonList
----TODO: @param opts? HarpoonToggleOptions
-function HarpoonUI:toggle_quick_menu(list)
+---@param opts? HarpoonToggleOptions
+function HarpoonUI:toggle_quick_menu(list, opts)
     opts = opts or {}
     if list == nil or self.win_id ~= nil then
         Logger:log("ui#toggle_quick_menu#closing", list and list.name)
@@ -123,7 +126,7 @@ function HarpoonUI:toggle_quick_menu(list)
     end
 
     Logger:log("ui#toggle_quick_menu#opening", list and list.name)
-    local win_id, bufnr = self:_create_window()
+    local win_id, bufnr = self:_create_window(opts)
 
     self.win_id = win_id
     self.bufnr = bufnr


### PR DESCRIPTION
Adds some ui options that can be overridden by the `toggle_opts` passed to `toggle_quick_menu`. I think being able to set defaults is nice so settings don't need to be set in keymaps.

Idea that I didn't add here but could be cool: as of nvim 0.10 floating windows can have a `footer` - we could use this to show the name of the current list for nvim nightly users.