### PR TITLE
feat: handler removal

### DIFF
--- a/lua/harpoon/listeners.lua
+++ b/lua/harpoon/listeners.lua
@@ -3,8 +3,8 @@
 --- TODO: Rename this... its an odd name "listeners"
 
 ---@class HarpoonListeners
----@field listeners (HarpoonListener)[]
----@field listenersByType (table<string, HarpoonListener>)[]
+---@field listeners table<HarpoonListener, HarpoonListener>
+---@field listenersByType table<string, table<HarpoonListener, HarpoonListener>>
 local HarpoonListeners = {}
 
 HarpoonListeners.__index = HarpoonListeners
@@ -16,16 +16,30 @@ function HarpoonListeners:new()
     }, self)
 end
 
+function HarpoonListeners:remove_listener(fn)
+    if self.listeners[fn] then
+        self.listeners[fn] = nil
+    end
+    for _, listeners in pairs(self.listenersByType) do
+        if listeners[fn] then
+            listeners[fn] = nil
+        end
+    end
+end
+
 ---@param cbOrType HarpoonListener | string
----@param cbOrNil HarpoonListener | string
+---@param cbOrNil HarpoonListener | string | nil
 function HarpoonListeners:add_listener(cbOrType, cbOrNil)
     if type(cbOrType) == "string" then
+        if not cbOrNil then
+            return
+        end
         if not self.listenersByType[cbOrType] then
             self.listenersByType[cbOrType] = {}
         end
-        table.insert(self.listenersByType[cbOrType], cbOrNil)
+        self.listenersByType[cbOrType][cbOrNil] = cbOrNil
     else
-        table.insert(self.listeners, cbOrType)
+        self.listeners[cbOrType] = cbOrType
     end
 end
 
@@ -36,13 +50,13 @@ end
 ---@param type string
 ---@param args any[] | any | nil
 function HarpoonListeners:emit(type, args)
-    for _, cb in ipairs(self.listeners) do
+    for _, cb in pairs(self.listeners) do
         cb(type, args)
     end
 
     local listeners = self.listenersByType[type]
     if listeners ~= nil then
-        for _, cb in ipairs(listeners) do
+        for _, cb in pairs(listeners) do
             cb(type, args)
         end
     end

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -124,6 +124,14 @@ function HarpoonUI:_create_window(toggle_opts)
     return win_id, bufnr
 end
 
+function HarpoonUI:update_contents()
+    if not self.active_list or not self.bufnr then
+        return
+    end
+    local contents = self.active_list:display()
+    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, contents)
+end
+
 ---@param list? HarpoonList
 ---TODO: @param opts? HarpoonToggleOptions
 function HarpoonUI:toggle_quick_menu(list, opts)
@@ -144,8 +152,7 @@ function HarpoonUI:toggle_quick_menu(list, opts)
     self.bufnr = bufnr
     self.active_list = list
 
-    local contents = self.active_list:display()
-    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, contents)
+    self:update_contents()
 end
 
 ---@param options? any


### PR DESCRIPTION
Restructures handlers a bit by using a map-like table instead of a list-like. The keys are the handlers, so they can easily be removed as needed (and are automatically deduplicated).

<strike> This allowed me to implement live-updating for the menu, so it will automatically update its contents if modified via Lua while it's open.</strike>

Also removed a zero from that `math.random` because it was sometimes causing an error to be thrown when naming the buffer.

If you like the handlers change but don't like the live-updating change, I'm happy to remove that.

I think it's important for handlers to be able to be removed / unregistered.

Edit: the live-update causes some weirdness so I am going to remove that and just leave this at handler removal for now.