### PR TITLE
feat: support prepopulating empty lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ There is quite a bit of behavior you can configure via `harpoon:setup()`
 ---@field select? (fun(list_item?: HarpoonListItem, list: HarpoonList, options: any?): nil)
 ---@field equals? (fun(list_line_a: HarpoonListItem, list_line_b: HarpoonListItem): boolean)
 ---@field add? fun(item: any?): HarpoonListItem
+---@field prepopulate? fun(): HarpoonListItem[]
 ---@field BufLeave? fun(evt: any, list: HarpoonList): nil
 ---@field VimLeavePre? fun(evt: any, list: HarpoonList): nil
 ---@field get_root_dir? fun(): string
@@ -160,6 +161,7 @@ There is quite a bit of behavior you can configure via `harpoon:setup()`
 * `select`: the action taken when selecting a list item. called from `list:select(idx, options)`
 * `equals`: how to compare two list items for equality
 * `add`: called when `list:append()` or `list:prepend()` is called.  called with an item, which will be a string, when adding through the ui menu
+* `prepopulate`: if present, called the first time `Harpoon:list()` is called for a given *empty* list.
 * `BufLeave`: this function is called for every list on BufLeave.  if you need custom behavior, this is the place
 * `VimLeavePre`: this function is called for every list on VimLeavePre.
 * `get_root_dir`: used for creating relative paths.  defaults to `vim.loop.cwd()`

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -14,6 +14,7 @@ M.DEFAULT_LIST = DEFAULT_LIST
 
 ---@class HarpoonPartialConfigItem
 ---@field select_with_nil? boolean defaults to false
+---@field prepopulate? fun():(HarpoonListItem[])
 ---@field encode? (fun(list_item: HarpoonListItem): string)
 ---@field decode? (fun(obj: string): any)
 ---@field display? (fun(list_item: HarpoonListItem): string)

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -64,6 +64,13 @@ function Harpoon:list(name)
     local list = List.decode(list_config, name, data)
     lists[name] = list
 
+    if list.config.prepopulate and list:length() == 0 then
+        local items = list.config.prepopulate() or {}
+        for _, item in ipairs(items) do
+            list:append(item)
+        end
+    end
+
     return list
 end
 


### PR DESCRIPTION
Suggested by @tris203

Adds support for lists which prepopulate their values when empty. This method on the list config is only run the first time the list is read from, if the list is empty. Not implemented by the default list.

This is important for lists of terminals and other things that are convenient to have pre-marked.

Another use case is pre-configuring projects by language. For example, auto-marking `src/main.rs` and `Cargo.toml` in a Rust project.

Example, prepopulate the default list with entries from `mini.visits` frecency index:

```lua
harpoon:setup({
  settings = {
    -- ...
  },
  default = {
    prepopulate = function()
      local Path = require("plenary.path")
      local cwd = vim.uv.cwd()
      local limit = 3
      return vim
        .iter(require("mini.visits").list_paths())
        :enumerate()
        :filter(function(i) -- because there's no `take(n)` in vim.iter
          return i <= limit
        end)
        :map(function(_, path)
          local p = Path:new(path):make_relative(cwd)
          return {
            value = p,
            context = {
              row = 1,
              col = 1,
            },
          }
        end)
        :totable()
    end,
  },
})
```