### PR TITLE
fix: check list.config.encode, default save_on_toggle to false

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -14,7 +14,7 @@ M.DEFAULT_LIST = DEFAULT_LIST
 
 ---@class HarpoonPartialConfigItem
 ---@field select_with_nil? boolean defaults to false
----@field encode? (fun(list_item: HarpoonListItem): string)
+---@field encode? (fun(list_item: HarpoonListItem): string) | boolean
 ---@field decode? (fun(obj: string): any)
 ---@field display? (fun(list_item: HarpoonListItem): string)
 ---@field select? (fun(list_item?: HarpoonListItem, list: HarpoonList, options: any?): nil)
@@ -25,7 +25,7 @@ M.DEFAULT_LIST = DEFAULT_LIST
 ---@field get_root_dir? fun(): string
 
 ---@class HarpoonSettings
----@field save_on_toggle boolean defaults to true
+---@field save_on_toggle boolean defaults to false
 ---@field sync_on_ui_close? boolean
 ---@field key (fun(): string)
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -86,7 +86,7 @@ end
 function Harpoon:sync()
     local key = self.config.settings.key()
     self:_for_each_list(function(list, _, list_name)
-        if list.encode == false then
+        if list.config.encode == false then
             return
         end
 


### PR DESCRIPTION
Fixes lists that don't encode by checking if `list.config.encode` is nil instead of checking `list.encode` (which will never be nil).

Also actually defaults `save_on_toggle` to true, because it says it defaults to true in several places (it also says false in some places? idk) and harpoon basically doesn't work without it unless `sync_on_ui_close` is enabled.