### PR TITLE
fix: remove a zero from the random buf name

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -8,7 +8,7 @@ local HARPOON_MENU = "__harpoon-menu__"
 -- simple reason here is that if we are deving harpoon, we will create several
 -- ui objects, each with their own buffer, which will cause the name to be
 -- duplicated and then we will get a vim error on nvim_buf_set_name
-local harpoon_menu_id = math.random(1000000)
+local harpoon_menu_id = math.random(100000)
 
 local function get_harpoon_menu_name()
     harpoon_menu_id = harpoon_menu_id + 1


### PR DESCRIPTION
This can cause an error when opening the UI. Removing a single zero fixes it. This fix is included in #408 but figured I'd add it here separately so it can be merged quickly.

sorry for the PR spam lol