### PR TITLE
feat(ui): accept title_pos option if specified

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -92,6 +92,7 @@ function HarpoonUI:_create_window(toggle_opts)
     local win_id = vim.api.nvim_open_win(bufnr, true, {
         relative = "editor",
         title = "Harpoon",
+        title_pos = toggle_opts.title_pos or "left",
         row = math.floor(((vim.o.lines - height) / 2) - 1),
         col = math.floor((vim.o.columns - width) / 2),
         width = width,

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -4,6 +4,7 @@ local Listeners = require("harpoon.listeners")
 
 ---@class HarpoonToggleOptions
 ---@field border? any this value is directly passed to nvim_open_win
+---@field title_pos? any this value is directly passed to nvim_open_win
 ---@field ui_fallback_width? number
 ---@field ui_width_ratio? number
 


### PR DESCRIPTION
This is related to #402.

This let's you revert back some of the UI looks.

```lua
local harpoon = require('harpoon')
harpoon.ui:toggle_quick_menu(harpoon:list()), { border = "rounded", title_pos = "center" })
```