### PR TITLE
Add lazy.nvim installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,38 @@ tmux windows, or dream up your own custom action and execute with a single key
 
 ## ⇁ Installation
 * neovim 0.8.0+ required
-* install using your favorite plugin manager (i am using `packer` in this case)
+* install using your favorite plugin manager
+
+Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
 ```lua
 use "nvim-lua/plenary.nvim" -- don't forget to add this one if you don't have it yet!
 use {
     "ThePrimeagen/harpoon",
     branch = "harpoon2",
     requires = { {"nvim-lua/plenary.nvim"} }
+}
+```
+
+Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+-- init.lua:
+{
+    "ThePrimeagen/harpoon",
+    branch = "harpoon2",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    opts = {},
+    config = function()
+        local harpoon = require("harpoon")
+        vim.keymap.set("n", "<leader>a", function() harpoon:list():append() end)
+        vim.keymap.set("n", "<C-e>", function() harpoon.ui:toggle_quick_menu(harpoon:list()) end)
+
+        vim.keymap.set("n", "<C-h>", function() harpoon:list():select(1) end)
+        vim.keymap.set("n", "<C-t>", function() harpoon:list():select(2) end)
+        vim.keymap.set("n", "<C-n>", function() harpoon:list():select(3) end)
+        vim.keymap.set("n", "<C-s>", function() harpoon:list():select(4) end)
+    end,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,17 @@ use {
 Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
--- init.lua:
-{
+-- ~/.config/nvim/lua/plugins/harpoon.lua
+return {
     "ThePrimeagen/harpoon",
     branch = "harpoon2",
     dependencies = { "nvim-lua/plenary.nvim" },
     opts = {},
     config = function()
         local harpoon = require("harpoon")
+
+        harpoon:setup()
+
         vim.keymap.set("n", "<leader>a", function() harpoon:list():append() end)
         vim.keymap.set("n", "<C-e>", function() harpoon.ui:toggle_quick_menu(harpoon:list()) end)
 


### PR DESCRIPTION
Just adding lazy.nvim instructions to the README to make it easier for folks to copy/paste into their config.