### PR TITLE
feat: add `LIST_READ` event

### DIFF
--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -1,5 +1,3 @@
---- TODO: Rename this... its an odd name "listeners"
-
 ---@class HarpoonExtensions
 ---@field listeners HarpoonExtension[]
 local HarpoonExtensions = {}
@@ -12,6 +10,7 @@ local HarpoonExtensions = {}
 ---@field UI_CREATE? fun(...): nil
 ---@field SETUP_CALLED? fun(...): nil
 ---@field LIST_CREATED? fun(...): nil
+---@field LIST_READ? fun(...): nil
 ---@field NAVIGATE? fun(...): nil
 
 HarpoonExtensions.__index = HarpoonExtensions
@@ -64,5 +63,6 @@ return {
         SETUP_CALLED = "SETUP_CALLED",
         LIST_CREATED = "LIST_CREATED",
         NAVIGATE = "NAVIGATE",
+        LIST_READ = "LIST_READ",
     },
 }

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -55,6 +55,7 @@ function Harpoon:list(name)
             self.data.seen[key] = {}
         end
         self.data.seen[key][name] = true
+        self._extensions:emit(Extensions.event_names.LIST_READ, existing_list)
         return existing_list
     end
 


### PR DESCRIPTION
Tiny change, but I think important as it would allow for some lists to be fully automated. Unsure if this should also be emitted after the list is created.

Event runs when a list is read but not for the first time (i.e. early return before `LIST_CREATE`)