### PR TITLE
ci: fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,12 @@ jobs:
             mkdir -p _neovim
             curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
+      - name: Dependencies
+        run: |
+            git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+            ln -s "$(pwd)" ~/.local/share/nvim/site/pack/vendor/start
       - name: Run tests
         run: |
           export PATH="${PWD}/_neovim/bin:${PATH}"
-          export VIM="${PWD}/_neovim/share/nvim/runtime"
           nvim --version
           make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
             rev: nightly/nvim-linux64.tar.gz
           - os: ubuntu-22.04
             rev: v0.9.0/nvim-linux64.tar.gz
-          - os: macos-12
-            rev: nightly/nvim-macos.tar.gz
-          - os: macos-12
-            rev: v0.9.0/nvim-macos.tar.gz
     steps:
       - uses: actions/checkout@v3
       - run: date +%F > todays-date

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
             - name: Setup
               run: |
                   sudo apt-get update
-                  sudo apt-get install luarocks
+                  sudo apt-get install luarocks -y
                   sudo luarocks install luacheck
 
             - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ lint:
 
 test:
 	echo "===> Testing"
-	nvim --headless -c "PlenaryBustedDirectory lua/harpoon/test"
+	nvim --headless --noplugin -u scripts/tests/minimal.vim \
+        -c "PlenaryBustedDirectory lua/harpoon/test/ {minimal_init = 'scripts/tests/minimal.vim'}"
 
 pr-ready: fmt lint test

--- a/scripts/tests/minimal.vim
+++ b/scripts/tests/minimal.vim
@@ -1,0 +1,3 @@
+set rtp+=.
+set rtp+=../plenary.nvim
+runtime! plugin/plenary.vim


### PR DESCRIPTION
Fixes the CI runs by adding the dependencies needed to run the test
Also includes a minimal init to scaffold a working neovim

uses minimal init's from here: https://github.com/nvim-lua/nvim-lua-plugin-template

additionally, I had to remove the mac testing as I couldn't get it to pass due to /tmp /private/tmp mapping issues

Example:
```
Fail	||	config default.create_list_item	
            ...er/work/harpoon/harpoon/lua/harpoon/test/config_spec.lua:21: Expected objects to be the same.
            Passed in:
            (table: 0x010e17a148) {
              [context] = {
                [col] = 1
                [row] = 3 }
             *[value] = '/tmp/harpoon-test' }
            Expected:
            (table: 0x010e17a0b8) {
              [context] = {
                [col] = 1
                [row] = 3 }
             *[value] = '/private/tmp/harpoon-test' }
```
Full run details: https://github.com/tris203/harpoon/actions/runs/7234139487

I tried a couple of things, including adding a get_tmp_path() to test.utils and then using that rather than hardcoded /tmps but it didn't work.

Perhaps somebody who knows mac better than me can fix.

Anyone on a mac, does os.tmpname() return /tmp or /private/tmp?

address #375 

