### PR TITLE
Add documentation to readme for previous and next shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ vim.keymap.set("n", "<C-h>", function() harpoon:list():select(1) end)
 vim.keymap.set("n", "<C-t>", function() harpoon:list():select(2) end)
 vim.keymap.set("n", "<C-n>", function() harpoon:list():select(3) end)
 vim.keymap.set("n", "<C-s>", function() harpoon:list():select(4) end)
+
+-- Toggle previous & next buffers stored within Harpoon list
+vim.keymap.set("n", "<C-S-P>", function() harpoon:list():prev() end)
+vim.keymap.set("n", "<C-S-N>", function() harpoon:list():next() end)
 ```
 
 ## ⇁ API


### PR DESCRIPTION
Added previous and next documentation to configuration in README for Harpoon2.

I realized I used my preference for shortcuts, happy to update to the suggested for Harpoon 1