### PR TITLE
Adjust UI_CREATE events

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -134,6 +134,9 @@ function HarpoonUI:toggle_quick_menu(list, opts)
         return
     end
 
+    -- grab the current file before opening the quick menu
+    local current_file = vim.api.nvim_buf_get_name(0)
+
     Logger:log("ui#toggle_quick_menu#opening", list and list.name)
     local win_id, bufnr = self:_create_window(opts)
 
@@ -147,6 +150,7 @@ function HarpoonUI:toggle_quick_menu(list, opts)
     Extensions.extensions:emit(Extensions.event_names.UI_CREATE, {
         win_id = win_id,
         bufnr = bufnr,
+        current_file = current_file,
     })
 end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -118,11 +118,6 @@ function HarpoonUI:_create_window(toggle_opts)
         win = win_id,
     })
 
-    Extensions.extensions:emit(Extensions.event_names.UI_CREATE, {
-        win_id = win_id,
-        bufnr = bufnr,
-    })
-
     return win_id, bufnr
 end
 
@@ -148,6 +143,11 @@ function HarpoonUI:toggle_quick_menu(list, opts)
 
     local contents = self.active_list:display()
     vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, contents)
+
+    Extensions.extensions:emit(Extensions.event_names.UI_CREATE, {
+        win_id = win_id,
+        bufnr = bufnr,
+    })
 end
 
 ---@param options? any


### PR DESCRIPTION
As discussed in #454, I've moved `UI_CREATE` to fire after the contents of the buffer have been added and created a `BEFORE_OPEN` event.