### PR TITLE
docs: document lazy.nvim instalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ use {
     requires = { {"nvim-lua/plenary.nvim"} }
 }
 ```
+* install using [lazy.nvim](https://github.com/folke/lazy.nvim)
+```lua
+{
+    "ThePrimeagen/harpoon",
+    branch = "harpoon2",
+    dependencies = { "nvim-lua/plenary.nvim" }
+}
+```
 
 ## ⇁ Getting Started
 


### PR DESCRIPTION
It seems like the documentation is kind of repetitive but it took a little time to get the right configuration while I was migrating from packer to lazy.nvim.

On this case the `requires` will be replaced by `dependencies`.