### PR TITLE
Added back the ui_nav_wrap feature

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -63,6 +63,8 @@ function M.get_default_config()
         },
 
         default = {
+            --- ui_nav_wrap allows the ability to enable(true) or disable(false) wrapping on prev and next list calls.
+            ui_nav_wrap = true,
 
             --- select_with_nill allows for a list to call select even if the provided item is nil
             select_with_nil = false,


### PR DESCRIPTION
Can we bring back the option to turn wrapping on/off when going through harpoon lists in [#387](https://github.com/ThePrimeagen/harpoon/pull/387)? It got removed in https://github.com/ThePrimeagen/harpoon/commit/fa73cd0c33f5a4d8b0084c70da1e48169f0053f8 and I'm not sure why.