### PR TITLE
feat: add title and ui_max_width toggle options

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -5,8 +5,10 @@ local Extensions = require("harpoon.extensions")
 ---@class HarpoonToggleOptions
 ---@field border? any this value is directly passed to nvim_open_win
 ---@field title_pos? any this value is directly passed to nvim_open_win
----@field ui_fallback_width? number
----@field ui_width_ratio? number
+---@field title? string this value is directly passed to nvim_open_win
+---@field ui_fallback_width? number used if we can't get the current window
+---@field ui_width_ratio? number this is the ratio of the editor window to use
+---@field ui_max_width? number this is the max width the window can be
 
 ---@return HarpoonToggleOptions
 local function toggle_config(config)
@@ -88,11 +90,15 @@ function HarpoonUI:_create_window(toggle_opts)
         width = math.floor(win[1].width * toggle_opts.ui_width_ratio)
     end
 
+    if toggle_opts.ui_max_width and width > toggle_opts.ui_max_width then
+        width = toggle_opts.ui_max_width
+    end
+
     local height = 8
     local bufnr = vim.api.nvim_create_buf(false, true)
     local win_id = vim.api.nvim_open_win(bufnr, true, {
         relative = "editor",
-        title = "Harpoon",
+        title = toggle_opts.title or "Harpoon",
         title_pos = toggle_opts.title_pos or "left",
         row = math.floor(((vim.o.lines - height) / 2) - 1),
         col = math.floor((vim.o.columns - width) / 2),


### PR DESCRIPTION
Add options for a custom title and max width for the UI.
Keep the same default behavior as before.

I noticed there are two couple TODO's in the UI regarding the toggle options. Can these be resolved or should there be an issue for them?

Does it make sense to refactor the `HarpoonToggleOptions` to be configurable from the plugin config?

How I am using these changes in my keymap:

```lua
        vim.keymap.set("n", "<leader>h", function()
            harpoon.ui:toggle_quick_menu(harpoon:list(), {
                border = "rounded",
                title = " Harpoon ",
                ui_max_width = 80,
            })
        end)
```