### PR TITLE
wip: add ui_context

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -17,7 +17,7 @@ M.DEFAULT_LIST = DEFAULT_LIST
 ---@field select_with_nil? boolean defaults to false
 ---@field encode? (fun(list_item: HarpoonListItem): string) | boolean
 ---@field decode? (fun(obj: string): any)
----@field display? (fun(list_item: HarpoonListItem): string)
+---@field display? (fun(ui_context: any, list_item: HarpoonListItem): string)
 ---@field select? (fun(list_item?: HarpoonListItem, list: HarpoonList, options: any?): nil)
 ---@field equals? (fun(list_line_a: HarpoonListItem, list_line_b: HarpoonListItem): boolean)
 ---@field create_list_item? fun(config: HarpoonPartialConfigItem, item: any?): HarpoonListItem
@@ -80,7 +80,7 @@ function M.get_default_config()
             end,
 
             ---@param list_item HarpoonListItem
-            display = function(list_item)
+            display = function(ui_context, list_item)
                 return list_item.value
             end,
 

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -120,8 +120,15 @@ function HarpoonList:get(index)
     return self.items[index]
 end
 
-function HarpoonList:get_by_display(name)
-    local displayed = self:display()
+--TODO: I don't think it makes sense to have these display methods in the list
+--module. I think they should be in the UI module, the list module should not
+--have anything to do with the display value. IMHO
+
+---@param ui_context any
+---@param name string
+---@return HarpoonItem|nil
+function HarpoonList:get_by_display(ui_context, name)
+    local displayed = self:display(ui_context)
     local index = index_of(displayed, name)
     if index == -1 then
         return nil
@@ -129,12 +136,16 @@ function HarpoonList:get_by_display(name)
     return self.items[index]
 end
 
+--TODO: I feel like it would make more sense to resolve by value and have a
+--reverse function for display to get to the value or something like that.
+
 --- much inefficiencies.  dun care
+---@param ui_context any
 ---@param displayed string[]
-function HarpoonList:resolve_displayed(displayed)
+function HarpoonList:resolve_displayed(ui_context, displayed)
     local new_list = {}
 
-    local list_displayed = self:display()
+    local list_displayed = self:display(ui_context)
 
     for i, v in ipairs(list_displayed) do
         local index = index_of(displayed, v)
@@ -218,10 +229,11 @@ function HarpoonList:prev(opts)
 end
 
 --- @return string[]
-function HarpoonList:display()
+--- @param ui_context any
+function HarpoonList:display(ui_context)
     local out = {}
     for _, v in ipairs(self.items) do
-        table.insert(out, self.config.display(v))
+        table.insert(out, self.config.display(ui_context, v))
     end
 
     return out

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -7,12 +7,14 @@ local Extensions = require("harpoon.extensions")
 ---@field title_pos? any this value is directly passed to nvim_open_win
 ---@field ui_fallback_width? number
 ---@field ui_width_ratio? number
+---@field context? any
 
 ---@return HarpoonToggleOptions
 local function toggle_config(config)
     return vim.tbl_extend("force", {
         ui_fallback_width = 69,
         ui_width_ratio = 0.62569,
+        context = {},
     }, config or {})
 end
 
@@ -21,6 +23,7 @@ end
 ---@field bufnr number
 ---@field settings HarpoonSettings
 ---@field active_list HarpoonList
+---@field context any
 local HarpoonUI = {}
 
 ---@param list HarpoonList
@@ -69,6 +72,7 @@ function HarpoonUI:close_menu()
     self.active_list = nil
     self.win_id = nil
     self.bufnr = nil
+    self.context = nil
 
     self.closing = false
 end
@@ -122,7 +126,7 @@ function HarpoonUI:_create_window(toggle_opts)
 end
 
 ---@param list? HarpoonList
----TODO: @param opts? HarpoonToggleOptions
+---@param opts? HarpoonToggleOptions
 function HarpoonUI:toggle_quick_menu(list, opts)
     opts = toggle_config(opts)
     if list == nil or self.win_id ~= nil then
@@ -140,11 +144,15 @@ function HarpoonUI:toggle_quick_menu(list, opts)
     Logger:log("ui#toggle_quick_menu#opening", list and list.name)
     local win_id, bufnr = self:_create_window(opts)
 
+    -- TODO: I am not a huge fan of this temporal coupling, but I don't know a
+    -- better way ATM seems fine to me since we are also dong it for win_id,
+    -- bufnr, and active_list
+    self.context = opts.context
     self.win_id = win_id
     self.bufnr = bufnr
     self.active_list = list
 
-    local contents = self.active_list:display()
+    local contents = self.active_list:display(opts.context)
     vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, contents)
 
     Extensions.extensions:emit(Extensions.event_names.UI_CREATE, {
@@ -161,7 +169,7 @@ function HarpoonUI:select_menu_item(options)
     -- must first save any updates potentially made to the list before
     -- navigating
     local list = Buffer.get_contents(self.bufnr)
-    self.active_list:resolve_displayed(list)
+    self.active_list:resolve_displayed(self.context, list)
 
     Logger:log(
         "ui#select_menu_item selecting item",
@@ -180,7 +188,7 @@ end
 function HarpoonUI:save()
     local list = Buffer.get_contents(self.bufnr)
     Logger:log("ui#save", list)
-    self.active_list:resolve_displayed(list)
+    self.active_list:resolve_displayed(self.context, list)
     if self.settings.sync_on_ui_close then
         require("harpoon"):sync()
     end


### PR DESCRIPTION
I've been playing around trying to make a custom list that will show the files relative to my current context. I would like to accomplish this by passing in context to the UI when I call my keymap. This works well because I can pass in the context I need to evaluate how I want to display it when I call my keymap.

```lua
vim.keymap.set("n", "<leader>h", function()
    local harpoon = require("harpoon")
    local path = vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
    -- ^ this wont work when called in HarpoonList:display() because it is the
    -- harpoon buffer which is in a different directory than the file I am editing
    harpoon.ui:toggle_quick_menu(harpoon:list("relative"), {
        context = path
    })
end)
```

This is working well for my use case, but is a WIP for a couple reasons:
1. I haven't done any unit tests
2. I think the display methods in `HarpoonList` need to be refactored into the ui so we have access to the context without having to pass it into `HarpoonList`.
3. Not sure about other use cases

This is related to issue #466 