### PR TITLE
feat: Makefile target for test cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 indent_style = space
 indent_size = 4
 insert_final_newline = true
+
+[{Makefile,*.mk}]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,8 @@ test:
 	nvim --headless --noplugin -u scripts/tests/minimal.vim \
         -c "PlenaryBustedDirectory lua/harpoon/test/ {minimal_init = 'scripts/tests/minimal.vim'}"
 
+clean: 
+	echo "===> Cleaning"
+	rm /tmp/lua_*
+
 pr-ready: fmt lint test


### PR DESCRIPTION
Add a Makefile target that will remove all the temporary files created during testing.
Also edit the .editorconfig so it will not use spaces in the Makefile.