### PR TITLE
Harpoon 2: Improve telescope setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In order to use [Telescope](https://github.com/nvim-telescope/telescope.nvim) as
 make sure to add `telescope` to your dependencies and paste this following snippet into your configuration.
 
 ```lua
+local finders = require("telescope.finders")
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 local harpoon = require('harpoon')
@@ -100,36 +101,21 @@ local function toggle_telescope(harpoon_files)
 
     require("telescope.pickers").new({}, {
         prompt_title = "Harpoon",
-        finder = require("telescope.finders").new_table({
+        finder = finders.new_table({
             results = file_paths,
         }),
         previewer = conf.file_previewer({}),
         sorter = conf.generic_sorter({}),
         -- Make telescope select buffer from harpoon list
         attach_mappings = function(_, map)
-            local function list_find(list, func)
-                for i, v in ipairs(list) do
-                    if func(v, i, list) then
-                        return i, v
-                    end
-                end
-            end
-
             actions.select_default:replace(function(prompt_bufnr)
-                local curr_picker = action_state.get_current_picker(prompt_bufnr)
                 local curr_entry = action_state.get_selected_entry()
                 if not curr_entry then
                     return
                 end
                 actions.close(prompt_bufnr)
 
-                local idx, _ = list_find(curr_picker.finder.results, function(v)
-                    if curr_entry.value == v.value then
-                        return true
-                    end
-                    return false
-                end)
-                harpoon:list():select(idx)
+                harpoon:list():select(curr_entry.index)
             end)
             -- Delete entries from harpoon list with <C-d>
             map({ 'n', 'i' }, '<C-d>', function(prompt_bufnr)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ In order to use [Telescope](https://github.com/nvim-telescope/telescope.nvim) as
 make sure to add `telescope` to your dependencies and paste this following snippet into your configuration.
 
 ```lua
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
 local harpoon = require('harpoon')
 harpoon:setup({})
 
@@ -103,6 +105,43 @@ local function toggle_telescope(harpoon_files)
         }),
         previewer = conf.file_previewer({}),
         sorter = conf.generic_sorter({}),
+        -- Make telescope select buffer from harpoon list
+        attach_mappings = function(_, map)
+            local function list_find(list, func)
+                for i, v in ipairs(list) do
+                    if func(v, i, list) then
+                        return i, v
+                    end
+                end
+            end
+
+            actions.select_default:replace(function(prompt_bufnr)
+                local curr_picker = action_state.get_current_picker(prompt_bufnr)
+                local curr_entry = action_state.get_selected_entry()
+                if not curr_entry then
+                    return
+                end
+                actions.close(prompt_bufnr)
+
+                local idx, _ = list_find(curr_picker.finder.results, function(v)
+                    if curr_entry.value == v.value then
+                        return true
+                    end
+                    return false
+                end)
+                harpoon:list():select(idx)
+            end)
+            -- Delete entries from harpoon list with <C-d>
+            map({ 'n', 'i' }, '<C-d>', function(prompt_bufnr)
+                local current_picker = action_state.get_current_picker(prompt_bufnr)
+
+                current_picker:delete_selection(function(selection)
+                    harpoon:list():removeAt(selection.index)
+                end)
+            end
+            )
+            return true
+        end
     }):find()
 end
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ In order to use [Telescope](https://github.com/nvim-telescope/telescope.nvim) as
 make sure to add `telescope` to your dependencies and paste this following snippet into your configuration.
 
 ```lua
+local conf = require("telescope.config").values
+local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
@@ -100,14 +102,13 @@ local harpoon = require('harpoon')
 harpoon:setup({})
 
 -- basic telescope configuration
-local conf = require("telescope.config").values
 local function toggle_telescope(harpoon_files)
     local file_paths = {}
     for _, item in ipairs(harpoon_files.items) do
         table.insert(file_paths, item.value)
     end
 
-    require("telescope.pickers").new({}, {
+    pickers.new({}, {
         prompt_title = "Harpoon",
         finder = finders.new_table({
             results = file_paths,

--- a/README.md
+++ b/README.md
@@ -95,26 +95,90 @@ make sure to add `telescope` to your dependencies and paste this following snipp
 ```lua
 local conf = require("telescope.config").values
 local pickers = require("telescope.pickers")
+local themes = require("telescope.themes")
 local finders = require("telescope.finders")
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 local harpoon = require('harpoon')
 harpoon:setup({})
 
--- basic telescope configuration
-local function toggle_telescope(harpoon_files)
-    local file_paths = {}
-    for _, item in ipairs(harpoon_files.items) do
-        table.insert(file_paths, item.value)
+local function generate_new_finder(harpoon_files)
+    local files = {}
+    for i, item in ipairs(harpoon_files.items) do
+        table.insert(files, i .. ". " .. item.value)
     end
 
-    pickers.new({}, {
+    return finders.new_table({
+        results = files,
+    })
+end
+
+-- move_mark_up will move the mark up in the list, refresh the picker's result list and move the selection accordingly
+local function move_mark_up(prompt_bufnr, harpoon_files)
+    local selection = action_state.get_selected_entry()
+    if not selection then
+        return
+    end
+    if selection.index == 1 then
+        return
+    end
+
+    local mark = harpoon_files.items[selection.index]
+
+    table.remove(harpoon_files.items, selection.index)
+    table.insert(harpoon_files.items, selection.index - 1, mark)
+
+    local current_picker = action_state.get_current_picker(prompt_bufnr)
+    current_picker:refresh(generate_new_finder(harpoon_files), {})
+
+    -- yes defer_fn is an awful solution. If you find a better one, please let the world know.
+    -- it's used here because we need to wait for the picker to refresh before we can set the selection
+    -- actions.move_selection_previous() doesn't work here because the selection gets reset to 0 on every refresh.
+    vim.defer_fn(function()
+        -- don't even bother finding out why this is -2 here. (i don't know either)
+        current_picker:set_selection(selection.index - 2)
+    end, 2) -- 2ms was the minimum delay I could find that worked without glitching out the picker
+end
+
+-- move_mark_down will move the mark down in the list, refresh the picker's result list and move the selection accordingly
+local function move_mark_down(prompt_bufnr, harpoon_files)
+    local selection = action_state.get_selected_entry()
+    if not selection then
+        return
+    end
+
+    local length = harpoon:list():length()
+    if selection.index == length then
+        return
+    end
+
+    local mark = harpoon_files.items[selection.index]
+
+    table.remove(harpoon_files.items, selection.index)
+    table.insert(harpoon_files.items, selection.index + 1, mark)
+
+    local current_picker = action_state.get_current_picker(prompt_bufnr)
+    current_picker:refresh(generate_new_finder(harpoon_files), {})
+
+    -- yes defer_fn is an awful solution. If you find a better one, please let the world know.
+    -- it's used here because we need to wait for the picker to refresh before we can set the selection
+    -- actions.move_selection_next() doesn't work here because the selection gets reset to 0 on every refresh.
+    vim.defer_fn(function()
+        current_picker:set_selection(selection.index)
+    end, 2) -- 2ms was the minimum delay I could find that worked without glitching out the picker
+end
+
+local function toggle_telescope(harpoon_files)
+    pickers.new(themes.get_dropdown({
+        --TODO: make previewer work.
+        previewer = false
+    }), {
         prompt_title = "Harpoon",
-        finder = finders.new_table({
-            results = file_paths,
-        }),
+        finder = generate_new_finder(harpoon_files),
         previewer = conf.file_previewer({}),
         sorter = conf.generic_sorter({}),
+        -- Initial mode, change this to your liking. Normal mode is better for navigating with j/k
+        initial_mode = 'normal',
         -- Make telescope select buffer from harpoon list
         attach_mappings = function(_, map)
             actions.select_default:replace(function(prompt_bufnr)
@@ -126,15 +190,30 @@ local function toggle_telescope(harpoon_files)
 
                 harpoon:list():select(curr_entry.index)
             end)
-            -- Delete entries from harpoon list with <C-d>
+            -- Delete entries in insert mode from harpoon list with <C-d>
+            -- Change the keybinding to your liking
             map({ 'n', 'i' }, '<C-d>', function(prompt_bufnr)
-                local current_picker = action_state.get_current_picker(prompt_bufnr)
+                local curr_picker = action_state.get_current_picker(prompt_bufnr)
 
-                current_picker:delete_selection(function(selection)
+                curr_picker:delete_selection(function(selection)
                     harpoon:list():removeAt(selection.index)
                 end)
-            end
+            end)
+            -- Move entries up and down with <C-j> and <C-k>
+            -- Change the keybinding to your liking
+            map({ 'n', 'i' },
+                '<C-j>',
+                function(prompt_bufnr)
+                    move_mark_down(prompt_bufnr, harpoon_files)
+                end
             )
+            map({ 'n', 'i' },
+                '<C-k>',
+                function(prompt_bufnr)
+                    move_mark_up(prompt_bufnr, harpoon_files)
+                end
+            )
+
             return true
         end
     }):find()

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ local action_state = require("telescope.actions.state")
 local harpoon = require('harpoon')
 harpoon:setup({})
 
+-- used to get the correct index of a mark in the telescope list
+local function list_indexOf(list, predicate)
+    for i, v in ipairs(list) do
+        if predicate(v) then
+            return i
+        end
+    end
+    return -1
+end
+
 local function generate_new_finder(harpoon_files)
     local files = {}
     for i, item in ipairs(harpoon_files.items) do
@@ -194,9 +204,15 @@ local function toggle_telescope(harpoon_files)
             -- Change the keybinding to your liking
             map({ 'n', 'i' }, '<C-d>', function(prompt_bufnr)
                 local curr_picker = action_state.get_current_picker(prompt_bufnr)
-
                 curr_picker:delete_selection(function(selection)
-                    harpoon:list():removeAt(selection.index)
+                    local mark_idx = list_indexOf(harpoon_files.items, function(v)
+                        return v.value == selection[1]
+                    end)
+                    if mark_idx == -1 then
+                        return
+                    end
+
+                    harpoon:list():removeAt(mark_idx)
                 end)
             end)
             -- Move entries up and down with <C-j> and <C-k>


### PR DESCRIPTION
The current documentation in `README.md` on setting Harpoon 2 with telescope is incomplete.
It does not open the buffer you selected in the picker with `<CR>`
It does not have any way to remove a buffer from the list using the picker.

The code snippet added to `README.md` in my commit is going to help users that would like to use Harpoon 2 with telescope.