### PR TITLE
normalize buffer names when saving the buffer position

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -181,10 +181,12 @@ function M.get_default_config()
                 }
             end,
 
-            BufLeave = function(arg, list)
+            BufLeave = function(arg, list, config)
                 local bufnr = arg.buf
                 local bufname = vim.api.nvim_buf_get_name(bufnr)
-                local item = list:get_by_display(bufname)
+                local item = list:get_by_display(
+                    normalize_path(bufname, config.get_root_dir())
+                )
 
                 if item then
                     local pos = vim.api.nvim_win_get_cursor(0)

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -147,7 +147,7 @@ function Harpoon.setup(self, partial_config)
                 self:_for_each_list(function(list, config)
                     local fn = config[ev.event]
                     if fn ~= nil then
-                        fn(ev, list)
+                        fn(ev, list, config)
                     end
 
                     if ev.event == "VimLeavePre" then


### PR DESCRIPTION
I'm not sure what's special about my setup, but `vim.api.nvim_buf_get_name` always returns the absolute path of a buffer. Including when no plugins are enabled. In case the bufname is already relative nothing changes so this should safely cover both cases.

This code also does not get called during VimLeavePre, as a result the position of the last buffer might not be persisted, not sure if this is intentional.
https://github.com/ThePrimeagen/harpoon/blob/harpoon2/lua/harpoon/init.lua#L148

Perhaps this also fixes the problem described in https://github.com/ThePrimeagen/harpoon/issues/441?