### PR TITLE
feat: Blazingly fast extension iteration

### DIFF
--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -23,7 +23,10 @@ end
 
 ---@param extension HarpoonExtension
 function HarpoonExtensions:add_listener(extension)
-    table.insert(self.listeners, extension)
+    for k, v in pairs(extension) do
+        self.listeners[k] = self.listeners[k] or {}
+        table.insert(self.listeners[k], v)
+    end
 end
 
 function HarpoonExtensions:clear_listeners()
@@ -33,9 +36,9 @@ end
 ---@param type string
 ---@param ... any
 function HarpoonExtensions:emit(type, ...)
-    for _, cb in ipairs(self.listeners) do
-        if cb[type] then
-            cb[type](...)
+    if self.listeners[type] then
+        for _, cb in ipairs(self.listeners[type]) do
+            cb(...)
         end
     end
 end


### PR DESCRIPTION
Currently, eveytime the extend method is called a new table is added to listeners.

This PR makes it so that only one table is maintained and the keys are the events. Every time the extend method is called the function gets appended to the key