### PR TITLE
fix/tests(ui): number nav selects from current list, not just default

### DIFF
--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -56,7 +56,8 @@ function Builtins.navigate_with_number()
         UI_CREATE = function(cx)
             for i = 1, 9 do
                 vim.keymap.set("n", "" .. i, function()
-                    require("harpoon"):list():select(i)
+                    vim.api.nvim_win_set_cursor(0, { i, 0 })
+                    require("harpoon.buffer"):run_select_command()
                 end, { buffer = cx.bufnr })
             end
         end,

--- a/lua/harpoon/test/ui_spec.lua
+++ b/lua/harpoon/test/ui_spec.lua
@@ -1,6 +1,7 @@
 local utils = require("harpoon.test.utils")
 local Buffer = require("harpoon.buffer")
 local harpoon = require("harpoon")
+local extensions = require("harpoon.extensions")
 
 local eq = assert.are.same
 local be = utils.before_each(os.tmpname())
@@ -187,5 +188,54 @@ describe("harpoon", function()
         eq(vim.api.nvim_win_is_valid(win_id), false)
         eq(harpoon.ui.bufnr, nil)
         eq(harpoon.ui.win_id, nil)
+    end)
+
+    it("opens the selected file", function()
+        local created_files = utils.fill_list_with_files(3, harpoon:list())
+
+        for i, file in ipairs(created_files) do
+            harpoon.ui:toggle_quick_menu(harpoon:list())
+            vim.api.nvim_win_set_cursor(0, { i, 0 })
+            require("harpoon.buffer"):run_select_command()
+
+            eq(vim.api.nvim_buf_get_name(0), file)
+        end
+    end)
+
+    it("can navigate with numbers on default list AND custom lists", function()
+        harpoon:setup({
+            ["cmd"] = {
+                select = function(list_item)
+                    vim.cmd(list_item.value)
+                end,
+            },
+        })
+        harpoon:extend(extensions.builtins.navigate_with_number())
+
+        local default_list = harpoon:list()
+        local created_files = utils.fill_list_with_files(3, default_list)
+
+        local cmd_list = harpoon:list("cmd")
+        local created_cmds = vim.tbl_map(function(filename)
+            return "lua vim.api.nvim_buf_set_lines(0, 0, -1, false, { '"
+                .. filename
+                .. "' })"
+        end, created_files)
+
+        harpoon.ui:toggle_quick_menu(cmd_list)
+        Buffer.set_contents(harpoon.ui.bufnr, created_cmds)
+        harpoon.ui:save()
+        harpoon.ui:close_menu()
+
+        for i, filename in ipairs(created_files) do
+            for j, list in ipairs({ default_list, cmd_list }) do
+                local expected_line = j == 1 and "test" or filename
+                harpoon.ui:toggle_quick_menu(list)
+                key(tostring(i))
+
+                eq(vim.api.nvim_buf_get_name(0), filename)
+                eq(expected_line, vim.api.nvim_get_current_line())
+            end
+        end
     end)
 end)


### PR DESCRIPTION
**Problem**: With the `navigate_by_number` extension enabled and a custom list displayed in the UI, pressing a number key opens a file from the default file list instead of doing whatever the custom list should do.

For example, pressing `2` while the UI shows a `cmd` list (like the README example), harpoon opens the second item on the default file list instead of running a command.

**Proposed fix**: Use `run_select_command` for the extension. This is the same function as if the user had pressed `<CR>` after moving the cursor to the list item. This keeps behavior consistent across both selection methods.

This PR also adds tests for the the standard selection method and the `navigate_with_number` extension.