### PR TITLE
fix(buffer): close the harpoon window when opening netrw inside it

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -81,6 +81,24 @@ function M.setup_autocmds_and_keymaps(bufnr)
             require("harpoon").ui:toggle_quick_menu()
         end,
     })
+
+    vim.api.nvim_create_autocmd("FileType", {
+        group = HarpoonGroup,
+        pattern = "*",
+        callback = function(ev)
+            vim.schedule(function()
+                local ui = require("harpoon").ui
+                if
+                    not ui.closing
+                    and ev.buf ~= ui.bufnr
+                    and ui.win_id == vim.api.nvim_get_current_win()
+                then
+                    require("harpoon").logger:log("toggle by FileType")
+                    ui:toggle_quick_menu()
+                end
+            end)
+        end,
+    })
 end
 
 ---@param bufnr number

--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -88,11 +88,12 @@ function M.setup_autocmds_and_keymaps(bufnr)
         callback = function(ev)
             vim.schedule(function()
                 local ui = require("harpoon").ui
-                if
-                    not ui.closing
-                    and ev.buf ~= ui.bufnr
-                    and ui.win_id == vim.api.nvim_get_current_win()
-                then
+                local current_win = vim.api.nvim_get_current_win()
+                local current_win_buf = vim.api.nvim_win_get_buf(current_win)
+                if ui.win_id ~= current_win or ev.buf ~= current_win_buf then
+                    return
+                end
+                if not ui.closing and ev.buf ~= ui.bufnr then
                     require("harpoon").logger:log("toggle by FileType")
                     ui:toggle_quick_menu()
                 end


### PR DESCRIPTION
Fixes #480.

## Explanation of the code:
**Note that this explanation talks only about netrw, but some other things could be causing the same problem as well.**

First of all the `BufLeave` autocmd does not work in this case (honestly I don't know why, my guess is it has to do something with the harpoon being `scratch`, `unlisted` buffer, couldn't find much in the docs). A possible solution would be to use the `BufHidden` autocmd. I tried, but it doesn't work, again probably because of `scratch` / `unlisted` properties of the buffer. So the hacky solution is to use `FileType` autocmd and look for the buffers that satisfy the following conditions:
- buffer is opened in the harpoon window
- its opening did not invoke the closing of the harpoon buffer

If such a buffer exists, we want to close the harpoon window and buffer (ui:toggle_qucik_menu()). It would look something like this:
```lua
    vim.api.nvim_create_autocmd("FileType", {
        group = HarpoonGroup,
        pattern = "*",
        callback = function(ev)            
            local ui = require("harpoon").ui
            local current_win = vim.api.nvim_get_current_win()
            local current_win_buf = vim.api.nvim_win_get_buf(current_win)
            if ui.win_id ~= current_win or ev.buf ~= current_win_buf then
                return
            end
            if not ui.closing and ev.buf ~= ui.bufnr then
                require("harpoon").logger:log("toggle by FileType")
                ui:toggle_quick_menu()
            end
        end,
    })

```

But then the new problem emerges, the netrw text gets 'merged' with the buffer that we were supposed to go to after closing the harpoon window. My guess (I could be totally wrong on this one) is that the following happens: 
1. the `FileType` autocmd closes the window when the `filetype` option for netrw has been set (the `FileType` event fires when the `filetype` option is set, according to the docs)
2. it closes the harpoon window in the middle of nvim loading netrw buffer (basically it doesn't leave enough time for netrw to load) which causes the netrw text to get 'merged' with the buffer that was active before opening the harpoon window. 

So the final solution looks the same as the above autocmd but the callback is wrapped inside `vim.schedule`. Again I could be totally wrong but I guess that what `vim.schedule` does is wait for neovim's main event loop (according to the docs), which gets free after it handles the loading of the netrw buffer, and then calls the function we specified. netrw gets loaded inside of the harpoon window -> the harpoon window closes -> it looks like it's instant and everyone is happy.  

I had the same problem in one of my projects, so if you need any additional info on this problem:
- [text merging thing I mentioned](https://github.com/NStefan002/speedtyper.nvim/issues/30)

If someone who ackchyually knows this stuff comes here and tells me that my guesses were completely wrong then I guess at least I tried to help and the solution does the job. BUT if I'm right... Oh, boy I'm the f'ing genius. 