### PR TITLE
Fix default list

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -202,7 +202,6 @@ function M.get_default_config()
                         break
                     end
                 end
-
             end,
 
             VimLeavePre = function(arg, list)

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -125,7 +125,7 @@ function M.get_default_config()
                 vim.api.nvim_set_current_buf(bufnr)
 
                 if set_position then
-                    vim.api.nvim_win_set_cursor(0, {
+                    pcall(vim.api.nvim_win_set_cursor, 0, {
                         list_item.context.row or 1,
                         list_item.context.col or 0,
                     })

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -108,6 +108,7 @@ function M.get_default_config()
                     bufnr = vim.fn.bufnr(list_item.value, true)
                 end
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
+                    vim.api.nvim_set_current_buf(bufnr)
                     vim.fn.bufload(bufnr)
                     vim.api.nvim_set_option_value("buflisted", true, {
                         buf = bufnr,

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -81,7 +81,7 @@ function M.get_default_config()
 
             ---@param list_item HarpoonListItem
             display = function(list_item)
-                return list_item.value
+                return list_item.context.name
             end,
 
             --- the select function is called when a user selects an item from
@@ -101,14 +101,15 @@ function M.get_default_config()
                     return
                 end
 
-                local bufnr = vim.fn.bufnr(list_item.value)
                 local set_position = false
-                if bufnr == -1 then
-                    set_position = true
-                    bufnr = vim.fn.bufnr(list_item.value, true)
-                end
+                local bufnr = nil
+
+                local name = list_item.context.name
+                local path = Path:new(name):absolute()
+                bufnr = vim.uri_to_bufnr(vim.uri_from_fname(path))
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
-                    vim.fn.bufload(bufnr)
+                    set_position = true
+                    pcall(vim.fn.bufload, bufnr)
                     vim.api.nvim_set_option_value("buflisted", true, {
                         buf = bufnr,
                     })
@@ -150,22 +151,20 @@ function M.get_default_config()
             ---@param name? any
             ---@return HarpoonListItem
             create_list_item = function(config, name)
-                name = name
-                    -- TODO: should we do path normalization???
-                    -- i know i have seen sometimes it becoming an absolute
-                    -- path, if that is the case we can use the context to
-                    -- store the bufname and then have value be the normalized
-                    -- value
-                    or normalize_path(
-                        vim.api.nvim_buf_get_name(
-                            vim.api.nvim_get_current_buf()
-                        ),
-                        config.get_root_dir()
-                    )
+                local bufnr = nil
+                local bufname = nil
+
+                if name == nil then
+                    bufnr = vim.api.nvim_get_current_buf()
+                    bufname = vim.api.nvim_buf_get_name(bufnr)
+                    name = Path:new(bufname):make_relative(config.get_root_dir())
+                else
+                    local path = Path:new(name):absolute()
+                    bufnr = vim.uri_to_bufnr(vim.uri_from_fname(path))
+                    bufname = vim.api.nvim_buf_get_name(bufnr)
+                end
 
                 Logger:log("config_default#create_list_item", name)
-
-                local bufnr = vim.fn.bufnr(name, false)
 
                 local pos = { 1, 0 }
                 if bufnr ~= -1 then
@@ -173,10 +172,11 @@ function M.get_default_config()
                 end
 
                 return {
-                    value = name,
+                    value = bufname,
                     context = {
                         row = pos[1],
                         col = pos[2],
+                        name = name,
                     },
                 }
             end,
@@ -184,26 +184,51 @@ function M.get_default_config()
             BufLeave = function(arg, list)
                 local bufnr = arg.buf
                 local bufname = vim.api.nvim_buf_get_name(bufnr)
-                local item = list:get_by_display(bufname)
+                for _, item in ipairs(list.items) do
+                    if item.value == bufname then
+                        local pos = vim.api.nvim_win_get_cursor(0)
 
-                if item then
-                    local pos = vim.api.nvim_win_get_cursor(0)
+                        Logger:log(
+                            "config_default#BufLeave updating position",
+                            bufnr,
+                            bufname,
+                            item,
+                            "to position",
+                            pos
+                        )
 
-                    Logger:log(
-                        "config_default#BufLeave updating position",
-                        bufnr,
-                        bufname,
-                        item,
-                        "to position",
-                        pos
-                    )
+                        item.context.row = pos[1]
+                        item.context.col = pos[2]
+                        break
+                    end
+                end
 
-                    item.context.row = pos[1]
-                    item.context.col = pos[2]
+            end,
+
+            VimLeavePre = function(arg, list)
+                local bufnr = arg.buf
+                local bufname = vim.api.nvim_buf_get_name(bufnr)
+                for _, item in ipairs(list.items) do
+                    if item.value == bufname then
+                        local pos = vim.api.nvim_win_get_cursor(0)
+
+                        Logger:log(
+                            "config_default#VimLeavePre updating position",
+                            bufnr,
+                            bufname,
+                            item,
+                            "to position",
+                            pos
+                        )
+
+                        item.context.row = pos[1]
+                        item.context.col = pos[2]
+                        break
+                    end
                 end
             end,
 
-            autocmds = { "BufLeave" },
+            autocmds = { "BufLeave", "VimLeavePre" },
         },
     }
 end

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -104,9 +104,8 @@ function M.get_default_config()
                 local set_position = false
                 local bufnr = nil
 
-                local name = list_item.context.name
-                local path = Path:new(name):absolute()
-                bufnr = vim.uri_to_bufnr(vim.uri_from_fname(path))
+                local bufname = list_item.value
+                bufnr = vim.uri_to_bufnr(vim.uri_from_fname(bufname))
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
                     set_position = true
                     pcall(vim.fn.bufload, bufnr)

--- a/lua/harpoon/test/config_spec.lua
+++ b/lua/harpoon/test/config_spec.lua
@@ -23,6 +23,7 @@ describe("config", function()
             context = {
                 row = 3,
                 col = 1,
+                name = "/tmp/harpoon-test",
             },
         })
     end)

--- a/lua/harpoon/test/harpoon_spec.lua
+++ b/lua/harpoon/test/harpoon_spec.lua
@@ -37,7 +37,7 @@ describe("harpoon", function()
         vim.api.nvim_set_current_buf(other_buf)
 
         local expected = {
-            { value = file_name, context = { row = row + 1, col = col } },
+            { value = file_name, context = { row = row + 1, col = col, name = file_name } },
         }
 
         eq(expected, list.items)
@@ -93,8 +93,8 @@ describe("harpoon", function()
         })
 
         eq(list.items, {
-            { value = file_name_2, context = { row = row_2, col = col_2 } },
-            { value = file_name_1, context = { row = row_1, col = col_1 } },
+            { value = file_name_2, context = { row = row_2, col = col_2, name = file_name_2 } },
+            { value = file_name_1, context = { row = row_1, col = col_1, name = file_name_1 } },
         })
 
         harpoon:list():append()
@@ -102,8 +102,8 @@ describe("harpoon", function()
         harpoon:list():prepend()
 
         eq(list.items, {
-            { value = file_name_2, context = { row = row_2, col = col_2 } },
-            { value = file_name_1, context = { row = row_1, col = col_1 } },
+            { value = file_name_2, context = { row = row_2, col = col_2, name = file_name_2 } },
+            { value = file_name_1, context = { row = row_1, col = col_1, name = file_name_1 } },
         })
     end)
 


### PR DESCRIPTION
These changes try to address the issue with using `vim.fn.bufnr()` for loading buffers (see #503), and uses absolute paths instead of relative ones, for internal operations.