### PR TITLE
fix: create common prefixed files correctly

### DIFF
--- a/lua/harpoon/test/harpoon_spec.lua
+++ b/lua/harpoon/test/harpoon_spec.lua
@@ -135,4 +135,20 @@ describe("harpoon", function()
         eq(true, list_created)
         eq(Config.DEFAULT_LIST, list_name)
     end)
+
+    it("should append files with a common prefix", function()
+        local file_name_1 = "/tmp/harpoon-test-123"
+        local file_name_2 = "/tmp/harpoon-test-12"
+
+        utils.create_file(file_name_1, {})
+        local list = harpoon:list():append()
+
+        utils.create_file(file_name_2, {})
+        harpoon:list():append()
+
+        eq(list.items, {
+            { value = file_name_1, context = { row = 1, col = 0 } },
+            { value = file_name_2, context = { row = 1, col = 0 } },
+        })
+    end)
 end)

--- a/lua/harpoon/test/utils.lua
+++ b/lua/harpoon/test/utils.lua
@@ -54,7 +54,7 @@ end
 ---@param name string
 ---@param contents string[]
 function M.create_file(name, contents, row, col)
-    local bufnr = vim.fn.bufnr(name, true)
+    local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(name))
     vim.api.nvim_set_option_value("bufhidden", "hide", {
         buf = bufnr,
     })


### PR DESCRIPTION
These changes should point out the issue with using `vim.fn.bufnr()`. The issue being: that the `...test-12`-file is being obscured or hidden (shadowed!?) by the `...test-123`-file.
Without the fix - inside `test/utils.lua` - the test should fail!