### PR TITLE
Fix for 444

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -108,6 +108,7 @@ function M.get_default_config()
                     bufnr = vim.fn.bufnr(list_item.value, true)
                 end
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
+                    vim.api.nvim_set_current_buf(bufnr)
                     vim.fn.bufload(bufnr)
                     vim.api.nvim_set_option_value("buflisted", true, {
                         buf = bufnr,


### PR DESCRIPTION
I modified my previous attempt of ignoring the swapfile-error from #444 in the tests.
Buffers are now being closed at the end of each test, so that they don't trigger the error in other tests.