### PR TITLE
Move Index Update for Nav Cycle Methods to HarpoonList:select

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -293,6 +293,7 @@ function HarpoonList:select(index, options)
             { list = self, item = item, idx = index }
         )
         self.config.select(item, self, options)
+        self._index = index
     end
 end
 
@@ -301,16 +302,16 @@ end
 function HarpoonList:next(opts)
     opts = opts or {}
 
-    self._index = self._index + 1
-    if self._index > self._length then
+    local index = self._index + 1
+    if index > self._length then
         if opts.ui_nav_wrap then
-            self._index = 1
+            index = 1
         else
-            self._index = self._length
+            index = self._length
         end
     end
 
-    self:select(self._index)
+    self:select(index)
 end
 
 ---
@@ -318,16 +319,16 @@ end
 function HarpoonList:prev(opts)
     opts = opts or {}
 
-    self._index = self._index - 1
-    if self._index < 1 then
+    local index = self._index - 1
+    if index < 1 then
         if opts.ui_nav_wrap then
-            self._index = #self.items
+            index = #self.items
         else
-            self._index = 1
+            index = 1
         end
     end
 
-    self:select(self._index)
+    self:select(index)
 end
 
 --- @return string[]


### PR DESCRIPTION
I changed the `HarpoonList:select()` method to update the
`HarpoonList:_index` attribute to the selected index for consistency with
the behavior of harpoon1 when selecting an item from the quick menu.

This is an important part of my workflow since I tend to construct my
lists of harpooned files as relative to each other (e.g. a test file
next to the source file it covers), so if I select a file from the list,
I expect using a keymap for `next()` or `prev()` to take me to the file that
is conceptually next or prev the current file in my workflow, but the
current behavior does not update the index on a `select()` call, only when
calling `next()` or `prev()`.

By moving the local `_index` update into the `select()` call, we have
consistent behavior regardless of how the list item is selected, but
this also means that other APIs in harpoon2 that call `select()` will
update the `_index` of the list, which may not be expected or desirable atm.

If this is a problem, I can make this optional using a config field similar to `save_on_toggle`, but I prefer keeping config to a minimum in my projects, so I did not take this approach with this PR.

Please let me know if you want me to make this optional, or feel free to close this PR if this conflicts with the desired behavior of harpoon2. :)