### PR TITLE
Get the current harpoon mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,11 @@ harpoon:setup({
 
 ### Getting the current mark
 If you want to be able to get the current mark for something like your
-status line you just need to call `:lua require("harpoon"):list():get_current_status()"`.
+status line you just need to call:
+
+```lua
+require("harpoon"):list():get_current_status()
+```
 
 The function will return the idx of the current mark if your current buffer is
 a mark. Otherwise, it will return nil.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ vim.keymap.set("n", "<C-S-N>", function() harpoon:list():next() end)
 
 ### Telescope
 
-In order to use [Telescope](https://github.com/nvim-telescope/telescope.nvim) as a UI, 
+In order to use [Telescope](https://github.com/nvim-telescope/telescope.nvim) as a UI,
 make sure to add `telescope` to your dependencies and paste this following snippet into your configuration.
 
 ```lua
@@ -174,6 +174,13 @@ harpoon:setup({
 })
 
 ```
+
+### Getting the current mark
+If you want to be able to get the current mark for something like your
+status line you just need to call `:lua require("harpoon"):list():get_current_status()"`.
+
+The function will return the idx of the current mark if your current buffer is
+a mark. Otherwise, it will return nil.
 
 ### Config
 There is quite a bit of behavior you can configure via `harpoon:setup()`
@@ -287,7 +294,7 @@ contribute start with an issue and I am totally willing for PRs, but I will be
 very conservative on what I take.  I don't want Harpoon _solving_ specific
 issues, I want it to create the proper hooks to solve any problem
 
-**Running Tests**  
+**Running Tests**
 To run the tests make sure [plenary](https://github.com/nvim-lua/plenary.nvim) is checked out in the parent directory of *this* repository, then run `make test`.
 
 ## ⇁ Social

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -116,6 +116,19 @@ function HarpoonList:removeAt(index)
     return self
 end
 
+---@return number | nil
+function HarpoonList:get_current_status()
+    local current_file = vim.api.nvim_buf_get_name(0):gsub(vim.fn.getcwd() .. "/", "")
+
+    for idx, item in ipairs(self.items) do
+        if item.value == current_file then
+            return idx
+        end
+    end
+
+    return nil
+end
+
 function HarpoonList:get(index)
     return self.items[index]
 end


### PR DESCRIPTION
In harpoon one there was a neat little function you could call to get the current status.

So I added this feature to harpoon two. If you're currently in a buffer that is a mark when you call this function it will return the idx of the mark, or it will return nil.

The function can be called by doing
```lua
require("harpoon"):list():get_current_status()
```