### PR TITLE
Prevent Harpoon Jumplist from Being Added to Jumplist

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -52,6 +52,9 @@ end
 
 ---@return HarpoonList
 function HarpoonList:append(item)
+    if vim.bo.buftype ~= "" then
+        return self
+    end
     item = item or self.config.create_list_item(self.config)
 
     local index = index_of(self.items, item, self.config)
@@ -69,6 +72,9 @@ end
 
 ---@return HarpoonList
 function HarpoonList:prepend(item)
+    if vim.bo.buftype ~= "" then
+        return self
+    end
     item = item or self.config.create_list_item(self.config)
     local index = index_of(self.items, item, self.config)
     Logger:log("HarpoonList:prepend", { item = item, index = index })


### PR DESCRIPTION
This is a small fix for #506 to prevent non-normal buffers like NvimTree, terminal, & the harpoon jumplist from being accidentally appended or prepended to the jumplist. If `vim.bo.buftype` is equal to `""` then that signifies that the buffer is a normal buffer.