### PR TITLE
config: use mkview and loadview to restore marks and cursors

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -100,7 +100,7 @@ function M.get_default_config()
                 if list_item == nil then
                     return
                 end
-
+                vim.cmd("silent! mkview") -- Store current state before switching buffers.
                 local bufnr = vim.fn.bufnr(list_item.value)
                 local set_position = false
                 if bufnr == -1 then
@@ -130,6 +130,7 @@ function M.get_default_config()
                         list_item.context.col or 0,
                     })
                 end
+                vim.cmd("silent! loadview") -- Restore marks, cursor position, etc.
 
                 Extensions.extensions:emit(Extensions.event_names.NAVIGATE, {
                     buffer = bufnr,
@@ -200,6 +201,7 @@ function M.get_default_config()
 
                     item.context.row = pos[1]
                     item.context.col = pos[2]
+                    vim.cmd("silent! mkview")
                 end
             end,
 

--- a/lua/harpoon/data.lua
+++ b/lua/harpoon/data.lua
@@ -130,6 +130,8 @@ function Data:sync()
         return
     end
 
+    vim.cmd("silent! mkview")
+
     local ok, data = pcall(read_data)
     if not ok then
         error("Harpoon: unable to sync data, error reading data file")


### PR DESCRIPTION
Vim has a builtin mechanism for saving and restoring cursor positions and marks across restarts. Leverage mkview and loadview to make harpoon restore marks and cursor positions after quitting.

https://www.reddit.com/r/vim/comments/ex1vlv/comment/fg63erw

Closes: #441