### PR TITLE
fix: The name is ....... sometimes too broad for a buffer

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -4,6 +4,9 @@ local Path = require("plenary.path")
 local function normalize_path(buf_name, root)
     return Path:new(buf_name):make_relative(root)
 end
+local function to_exact_name(value)
+    return "^" .. value .. "$"
+end
 
 local M = {}
 local DEFAULT_LIST = "__harpoon_files"
@@ -101,11 +104,12 @@ function M.get_default_config()
                     return
                 end
 
-                local bufnr = vim.fn.bufnr(list_item.value)
+                local bufnr = vim.fn.bufnr(to_exact_name(list_item.value))
                 local set_position = false
-                if bufnr == -1 then
+                if bufnr == -1 then -- must create a buffer!
                     set_position = true
-                    bufnr = vim.fn.bufnr(list_item.value, true)
+                    -- bufnr = vim.fn.bufnr(list_item.value, true)
+                    bufnr = vim.fn.bufadd(list_item.value)
                 end
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
                     vim.fn.bufload(bufnr)


### PR DESCRIPTION
Fixes issue: #540 

Related: This [PR](https://github.com/ThePrimeagen/harpoon/pull/503), regarding tests.

To consider:

1. Maybe there are more places where something similar happens
2. Maybe the question "is there a buffer with this exact name" should be asked to `harpoon.buffer.lua`
3. I could not get a test going. Perhaps, this is more an e2e test, needing a `testdata` folder, with 2 files and a harpoon.json

Non-failing test:

```lua
it("can handle the same filename in different directories", function()
    local file_one = "/tmp/namespace/init.lua"
    local buf_one = utils.create_file(file_one, { "foo", "bar" }, 1, 0)
    harpoon:list():append()

    local file_two = "/tmp/init.lua"
    local buf_two = utils.create_file(file_two, {
        "baz",
        "qux",
    }, 1, 0)
    harpoon:list():append()

    harpoon:sync()
    local list = harpoon:list()

    eq(list.items, {
        { value = file_one, context = { row = 1, col = 0 } },
        { value = file_two, context = { row = 1, col = 0 } },
    })

    vim.cmd("bwipeout! " .. buf_one)
    vim.cmd("bwipeout! " .. buf_two)

    harpoon:list():select(1)
    eq("/tmp/namespace/init.lua", vim.api.nvim_buf_get_name(0))
    harpoon:list():select(2)
    eq("/tmp/init.lua", vim.api.nvim_buf_get_name(0))
end)
``` 