### PR TITLE
feat(list-api): expose index for later usage

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -126,7 +126,7 @@ function HarpoonList:get_by_display(name)
     if index == -1 then
         return nil
     end
-    return self.items[index]
+    return self.items[index], index
 end
 
 --- much inefficiencies.  dun care


### PR DESCRIPTION
- I have a custom append/prepend list where I need to notify the user if current file is already in the list, if it is, I want to hint the use for the exact index, so we can go faster