### PR TITLE
Added support for "blazing fast" replacement of files.

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -67,6 +67,23 @@ function HarpoonList:append(item)
     return self
 end
 
+
+---@param index number
+---@return HarpoonList
+function HarpoonList:replace(index)
+    local item = self.config.create_list_item(self.config)
+
+    if index < 1 or index > #(self.items) then
+        return self
+    end
+
+    self.items[index] = item
+
+    Logger:log("HarpoonList:replace", { item = item, index = index })
+
+    return self
+end
+
 ---@return HarpoonList
 function HarpoonList:prepend(item)
     item = item or self.config.create_list_item(self.config)


### PR DESCRIPTION
# The issue:

The philosophy of Harpoon is to increase developer productivity by minimizing keystrokes by setting hotkeys to navigate between files. Even though the addition to the front and back of the list is really simple. We currently do not have a way of editing this list quickly. As a daily user of Harpoon, I find myself countless times needing to reuse one of the main four indexes (the main four hotkeys on the "home row"), and even for a pro NeoVim user, the amount of necessary strokes to add a new file while keeping certain files in their respective position is quite big.

# The solution:

Add a replace function to map a keybinding to swap a file at a certain index with the current one. For example. If we have the following keymaps:

```lua
vim.keymap.set("n", "<C-h>", function() harpoon:list():select(1) end)
vim.keymap.set("n", "<C-t>", function() harpoon:list():select(2) end)
vim.keymap.set("n", "<C-n>", function() harpoon:list():select(3) end)
vim.keymap.set("n", "<C-s>", function() harpoon:list():select(4) end)
```

We could have the following replace keymaps to quickly set either of those positions:

```lua
vim.keymap.set("n", "<leader>sh", function() harpoon:list():replace(1) end)
vim.keymap.set("n", "<leader>st", function() harpoon:list():replace(2) end)
vim.keymap.set("n", "<leader>sn", function() harpoon:list():replace(3) end)
vim.keymap.set("n", "<leader>ss", function() harpoon:list():replace(4) end)
```

This would make swapping intuitive and easy. If I want to replace the file at index 1, I use a similar keybinding to switch to it. which makes the hotkeys engrained in the brain easily like "I want to put "this" file in "this" key.