### PR TITLE
Fix error on item select: Missing length argument (Resolves #546)

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -167,7 +167,8 @@ function HarpoonUI:select_menu_item(options)
     -- must first save any updates potentially made to the list before
     -- navigating
     local list = Buffer.get_contents(self.bufnr)
-    self.active_list:resolve_displayed(list)
+    local length = #list
+    self.active_list:resolve_displayed(list, length)
 
     Logger:log(
         "ui#select_menu_item selecting item",


### PR DESCRIPTION
Addresses the following error resulting from not passing `length` param on line 170:
```
E5108: Error executing lua: ...kaze/.local/share/nvim/lazy/harpoon/lua/harpoon/list.lua:242: 'for' limit must be a number
stack traceback:
        ...kaze/.local/share/nvim/lazy/harpoon/lua/harpoon/list.lua:242: in function 'resolve_displayed'
        ...makaze/.local/share/nvim/lazy/harpoon/lua/harpoon/ui.lua:170: in function 'select_menu_item'
        ...ze/.local/share/nvim/lazy/harpoon/lua/harpoon/buffer.lua:21: in function 'run_select_command'
        ...ze/.local/share/nvim/lazy/harpoon/lua/harpoon/buffer.lua:61: in function <...ze/.local/share/nvim/lazy/harpoon/lua/harpoon/buffer.lua:60>
```