### PR TITLE
fix(setup): merge configuration inside `harpoon.setup()`

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -37,18 +37,12 @@ end
 
 ---@return Harpoon
 function Harpoon:new()
-    local config = Config.get_default_config()
-
     local harpoon = setmetatable({
-        config = config,
-        data = Data.Data:new(config),
         logger = Log,
-        ui = Ui:new(config.settings),
         _extensions = Extensions.extensions,
         lists = {},
         hooks_setup = false,
     }, self)
-    sync_on_change(harpoon)
 
     return harpoon
 end
@@ -145,9 +139,12 @@ function Harpoon.setup(self, partial_config)
     end
 
     ---@diagnostic disable-next-line: param-type-mismatch
-    self.config = Config.merge_config(partial_config, self.config)
+    self.config = Config.merge_config(partial_config, Config.get_default_config())
+    self.data = Data.Data:new(self.config)
+    self.ui = Ui:new(self.config.settings)
     self.ui:configure(self.config.settings)
     self._extensions:emit(Extensions.event_names.SETUP_CALLED, self.config)
+    sync_on_change(the_harpoon)
 
     ---TODO: should we go through every seen list and update its config?
 

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -37,8 +37,12 @@ end
 
 ---@return Harpoon
 function Harpoon:new()
+    local config = Config.get_default_config()
+
     local harpoon = setmetatable({
+        config = config,
         logger = Log,
+        ui = Ui:new(config.settings),
         _extensions = Extensions.extensions,
         lists = {},
         hooks_setup = false,
@@ -139,9 +143,8 @@ function Harpoon.setup(self, partial_config)
     end
 
     ---@diagnostic disable-next-line: param-type-mismatch
-    self.config = Config.merge_config(partial_config, Config.get_default_config())
+    self.config = Config.merge_config(partial_config, self.config)
     self.data = Data.Data:new(self.config)
-    self.ui = Ui:new(self.config.settings)
     self.ui:configure(self.config.settings)
     self._extensions:emit(Extensions.event_names.SETUP_CALLED, self.config)
     sync_on_change(the_harpoon)


### PR DESCRIPTION
Instead of initializing the users configuration inside `harpoon:new()`, do it when `harpoon:setup({})` is called. This fixes the issue, when using the `settings.key`-function for the setup-call.

This change brakes one of the testies :\