### PR TITLE
Fix deprecation warning typo

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -102,7 +102,7 @@ end
 ---@param item? HarpoonListItem
 ---@return HarpoonList
 function HarpoonList:append(item)
-    print("APPEND IS DEPRICATED -- PLEASE USE `add`")
+    print("APPEND IS DEPRECATED -- PLEASE USE `add`")
     return self:add(item)
 end
 


### PR DESCRIPTION
Just a quick typo fix I noticed today after upgrading to latest and having my setup still set to use `append`. Thanks for the great work on this!