### PR TITLE
fix(ui_nav_wrap): fix cycling with `list:next()` and `list:prev()`

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -297,7 +297,7 @@ function HarpoonList:next(opts)
 
     self._index = self._index + 1
     if self._index > self._length then
-        if opts.ui_nav_wrap then
+        if opts.ui_nav_wrap ~= false then
             self._index = 1
         else
             self._index = self._length
@@ -314,7 +314,7 @@ function HarpoonList:prev(opts)
 
     self._index = self._index - 1
     if self._index < 1 then
-        if opts.ui_nav_wrap then
+        if opts.ui_nav_wrap ~= false then
             self._index = #self.items
         else
             self._index = 1


### PR DESCRIPTION
Allow the UI to cycle through the marks, by default. To disable cycling, pass `ui_nav_wrap=false`:

```lua
require("harpoon"):list():prev({ ui_nav_wrap = false })
require("harpoon"):list():next({ ui_nav_wrap = false })
```

This was mentioned in #461 and #341.