### PR TITLE
fix(encode): use a `for`-loop, instead of `next()` or `ipairs()`, to prevent loss of data

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -344,8 +344,11 @@ end
 --- @return string[]
 function HarpoonList:encode()
     local out = {}
-    for _, v in ipairs(self.items) do
-        table.insert(out, self.config.encode(v))
+    local items = self.items
+    local i, v = next(items, nil)
+    while i do
+        out[i] = self.config.encode(v)
+        i, v = next(items, i)
     end
 
     return out
@@ -358,8 +361,14 @@ end
 function HarpoonList.decode(list_config, name, items)
     local list_items = {}
 
-    for _, item in ipairs(items) do
-        table.insert(list_items, list_config.decode(item))
+    local i, item = next(items, nil)
+    while i do
+        if item == vim.NIL then
+            list_items[i] = nil -- allow nil-values
+        else
+            list_items[i] = list_config.decode(item)
+        end
+        i, item = next(items, i)
     end
 
     return HarpoonList:new(list_config, name, list_items)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -345,10 +345,11 @@ end
 function HarpoonList:encode()
     local out = {}
     local items = self.items
-    local i, v = next(items, nil)
-    while i do
-        out[i] = self.config.encode(v)
-        i, v = next(items, i)
+    for i = 1, self._length do
+        local item = items[i]
+        if item then
+            out[i] = self.config.encode(items[i])
+        end
     end
 
     return out
@@ -361,14 +362,13 @@ end
 function HarpoonList.decode(list_config, name, items)
     local list_items = {}
 
-    local i, item = next(items, nil)
-    while i do
+    for i = 1, #items do
+        local item = items[i]
         if item == vim.NIL then
             list_items[i] = nil -- allow nil-values
         else
             list_items[i] = list_config.decode(item)
         end
-        i, item = next(items, i)
     end
 
     return HarpoonList:new(list_config, name, list_items)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -348,7 +348,7 @@ function HarpoonList:encode()
     for i = 1, self._length do
         local item = items[i]
         if item then
-            out[i] = self.config.encode(items[i])
+            out[i] = self.config.encode(item)
         end
     end
 

--- a/lua/harpoon/test/harpoon_spec.lua
+++ b/lua/harpoon/test/harpoon_spec.lua
@@ -122,6 +122,31 @@ describe("harpoon", function()
         })
     end)
 
+    it("should ignore removed items", function()
+        local list = harpoon:list()
+
+        utils.create_file("/tmp/harpoon-test1", {}, 1, 0)
+        list:add()
+
+        utils.create_file("/tmp/harpoon-test2", {}, 1, 0)
+        list:add()
+
+        utils.create_file("/tmp/harpoon-test3", {}, 1, 0)
+        list:add()
+
+        list:remove_at(2) -- remove the second item
+
+        local count_items = 0
+        local encoded_items = list:encode()
+        local i, _ = next(encoded_items, nil)
+        while i do
+            count_items = count_items + 1
+            i, _ = next(encoded_items, i)
+        end
+
+        eq(2, count_items, "expecting two items in the list")
+    end)
+
     it("out of bounds test: row over", function()
         out_of_bounds_test({
             row = 5,


### PR DESCRIPTION
This fixes the issue, when there's an empty line inside the quick-menu, which causes everything after the blank line to be forgotten (after Neovim is restarted).

This also restores the blank lines, which I'm not certain of is expected or not?!