### PR TITLE
feat(index-tracking): keep track of the `list._index` while navigating

### DIFF
--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -29,18 +29,6 @@ end
 
 ---@param bufnr number
 function M.setup_autocmds_and_keymaps(bufnr)
-    local curr_file = vim.api.nvim_buf_get_name(0)
-    local cmd = string.format(
-        "autocmd Filetype harpoon "
-            .. "let path = '%s' | call clearmatches() | "
-            -- move the cursor to the line containing the current filename
-            .. "call search('\\V'.path.'\\$') | "
-            -- add a hl group to that line
-            .. "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
-        curr_file:gsub("\\", "\\\\")
-    )
-    vim.cmd(cmd)
-
     if vim.api.nvim_buf_get_name(bufnr) == "" then
         vim.api.nvim_buf_set_name(bufnr, get_harpoon_menu_name())
     end

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -344,8 +344,11 @@ end
 --- @return string[]
 function HarpoonList:encode()
     local out = {}
-    for _, v in ipairs(self.items) do
-        table.insert(out, self.config.encode(v))
+    local items = self.items
+    local i, v = next(items, nil)
+    while i do
+        out[i] = self.config.encode(v)
+        i, v = next(items, i)
     end
 
     return out
@@ -358,8 +361,14 @@ end
 function HarpoonList.decode(list_config, name, items)
     local list_items = {}
 
-    for _, item in ipairs(items) do
-        table.insert(list_items, list_config.decode(item))
+    local i, item = next(items, nil)
+    while i do
+        if item == vim.NIL then
+            list_items[i] = nil -- allow nil-values
+        else
+            list_items[i] = list_config.decode(item)
+        end
+        i, item = next(items, i)
     end
 
     return HarpoonList:new(list_config, name, list_items)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -345,10 +345,11 @@ end
 function HarpoonList:encode()
     local out = {}
     local items = self.items
-    local i, v = next(items, nil)
-    while i do
-        out[i] = self.config.encode(v)
-        i, v = next(items, i)
+    for i = 1, self._length do
+        local item = items[i]
+        if item then
+            out[i] = self.config.encode(items[i])
+        end
     end
 
     return out
@@ -361,14 +362,13 @@ end
 function HarpoonList.decode(list_config, name, items)
     local list_items = {}
 
-    local i, item = next(items, nil)
-    while i do
+    for i = 1, #items do
+        local item = items[i]
         if item == vim.NIL then
             list_items[i] = nil -- allow nil-values
         else
             list_items[i] = list_config.decode(item)
         end
-        i, item = next(items, i)
     end
 
     return HarpoonList:new(list_config, name, list_items)

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -89,16 +89,15 @@ local sync_index = function(list, options)
         local relname = Path:new(filename):make_relative(config.get_root_dir())
         if bufnr == vim.fn.bufnr(relname, false) then
             local element = config.create_list_item(config, relname)
-            local index_found = index_of(list.items, list._length, element, config)
+            local index_found =
+                index_of(list.items, list._length, element, config)
             if index_found > -1 then
                 list._index = index_found
-            -- elseif index then
-            --     list._index = index
             end
         elseif index ~= nil then
             list._index = index
         end
-    elseif (index ~= nil) then
+    elseif index ~= nil then
         list._index = index
     end
 end
@@ -115,10 +114,10 @@ function HarpoonList:new(config, name, items)
     }, self)
     vim.api.nvim_create_autocmd({ "BufEnter" }, {
         pattern = { "*" },
-        callback = function (args)
+        callback = function(args)
             sync_index(list, {
                 bufnr = args.buf,
-                filename = args.file
+                filename = args.file,
             })
         end,
     })
@@ -236,7 +235,6 @@ function HarpoonList:remove(item)
             sync_index(self, {
                 bufnr = current_buffer,
                 filename = vim.api.nvim_buf_get_name(current_buffer),
-                -- index = index <= self._index and self._index - 1 or self._index,
             })
 
             Extensions.extensions:emit(
@@ -265,7 +263,6 @@ function HarpoonList:remove_at(index)
         sync_index(self, {
             bufnr = current_buffer,
             filename = vim.api.nvim_buf_get_name(current_buffer),
-            -- index = index <= self._index and self._index - 1 or self._index,
         })
 
         Extensions.extensions:emit(

--- a/lua/harpoon/test/harpoon_spec.lua
+++ b/lua/harpoon/test/harpoon_spec.lua
@@ -122,6 +122,31 @@ describe("harpoon", function()
         })
     end)
 
+    it("should ignore removed items", function()
+        local list = harpoon:list()
+
+        utils.create_file("/tmp/harpoon-test1", {}, 1, 0)
+        list:add()
+
+        utils.create_file("/tmp/harpoon-test2", {}, 1, 0)
+        list:add()
+
+        utils.create_file("/tmp/harpoon-test3", {}, 1, 0)
+        list:add()
+
+        list:remove_at(2) -- remove the second item
+
+        local count_items = 0
+        local encoded_items = list:encode()
+        local i, _ = next(encoded_items, nil)
+        while i do
+            count_items = count_items + 1
+            i, _ = next(encoded_items, i)
+        end
+
+        eq(2, count_items, "expecting two items in the list")
+    end)
+
     it("out of bounds test: row over", function()
         out_of_bounds_test({
             row = 5,

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -153,6 +153,12 @@ function HarpoonUI:toggle_quick_menu(list, opts)
     local contents = self.active_list:display()
     vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, contents)
 
+    local index = list._index
+
+    if index > 0 then
+        vim.api.nvim_win_set_cursor(win_id, {index, 0})
+    end
+
     Extensions.extensions:emit(Extensions.event_names.UI_CREATE, {
         win_id = win_id,
         bufnr = bufnr,
@@ -173,7 +179,7 @@ function HarpoonUI:select_menu_item(options)
     -- must first save any updates potentially made to the list before
     -- navigating
     local list, length = self:_get_processed_ui_contents()
-    self.active_list:resolve_displayed(list, length)
+    self.active_list:resolve_displayed(list, length, { win_id = self.win_id })
 
     Logger:log(
         "ui#select_menu_item selecting item",
@@ -193,7 +199,7 @@ function HarpoonUI:save()
     local list, length = self:_get_processed_ui_contents()
 
     Logger:log("ui#save", list)
-    self.active_list:resolve_displayed(list, length)
+    self.active_list:resolve_displayed(list, length, { win_id = self.win_id })
     if self.settings.sync_on_ui_close then
         require("harpoon"):sync()
     end

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -156,7 +156,7 @@ function HarpoonUI:toggle_quick_menu(list, opts)
     local index = list._index
 
     if index > 0 then
-        vim.api.nvim_win_set_cursor(win_id, {index, 0})
+        vim.api.nvim_win_set_cursor(win_id, { index, 0 })
     end
 
     Extensions.extensions:emit(Extensions.event_names.UI_CREATE, {


### PR DESCRIPTION
This change tries to keep track of the `list._index`, by using an `autocmd` for `BufEnter` - which updates the index when entering a harpooned file - and setting the index for different functions inside the list.

There's room for improvements, but maybe it can help!?

This also removes the `autocmd Filetype harpoon` - which didn't seem to highlight the row?! - and replaces it with passing the `index` for setting the cursor to a row.

Maybe there should be an user-option, to enable this?!

This also merges #573, since I felt it's somehow related.