### PR TITLE
fix(swapfile): ignore the swapfile-message

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -114,7 +114,17 @@ function M.get_default_config()
                     bufnr = vim.fn.bufadd(list_item.value)
                 end
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
-                    vim.fn.bufload(bufnr)
+                    local abort = false
+                    xpcall(vim.api.nvim_command, function(e)
+                        if e == "Vim(buffer):E325: ATTENTION" then -- recover or quit
+                            abort = true
+                        elseif e == "Keyboard interrupt" then -- abort
+                            abort = true
+                        end
+                    end, string.format("%s %d", "buffer", bufnr))
+                    if abort == true then
+                        return
+                    end
                     vim.api.nvim_set_option_value("buflisted", true, {
                         buf = bufnr,
                     })

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -121,7 +121,11 @@ function M.get_default_config()
                         elseif e == "Keyboard interrupt" then -- abort
                             abort = true
                         end
-                    end, string.format("%s %d", "buffer", bufnr))
+                    end, string.format(
+                        "%s %d",
+                        "buffer",
+                        bufnr
+                    ))
                     if abort == true then
                         return
                     end


### PR DESCRIPTION
This change supresses the `E325: ATTENTION`-message - when a swapfile is encountered - by catching the error and stop execution when the user chooses one of `(R)ecover`, `(Q)uit` or `(A)bort`.

This addresses the issues https://github.com/ThePrimeagen/harpoon/issues/444 (?) and https://github.com/ThePrimeagen/harpoon/issues/570.

This duplicates PR #571.