### PR TITLE
feat: luarocks/rocks.nvim support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,32 @@
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request: # Runs a test install without uploading on PR
+  workflow_dispatch: # Allow manual trigger (e.g. if a tagged build failed)
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            plenary.nvim
+          labels: |
+            neovim
+          summary: Getting you where you want with the fewest keystrokes.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        with:
+          release-type: simple
+          package-name: harpoon


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [luarocks.org](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

With luarocks/rocks.nvim, it is [the plugin authors' responsibility to declare dependencies - not the user's](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file#grey_question-why-rocksnvim).
Installing this plugin becomes as simple as `:Rocks install harpoon`.

### Things done:

- Add a workflow that publishes tags to luarocks.org when a tag or release is pushed.
- Add a release-please workflow that creates release PRs with SemVer versioning based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

The workflows are based on [this guide](https://github.com/vhyrro/sample-luarocks-plugin)

### Notes:

> [!IMPORTANT]
> 
> - **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.

- On each merge to `master` (if this lands on `master`), the `release-please` workflow creates (or updates an existing) release PR.
- You decide when to merge release PRs.
  Doing so will result in a SemVer tag, a changelog update, and a GitHub release, which will trigger the `luarocks` workflow.
  If you would like versioning to start from a specific version (e.g. 2.0.0), you can [configure this with a manifest](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).
- Tagged releases are installed locally and then published to luarocks.org.
  - If you push tags from a local checkout, the workflow is triggered automatically.
  - If you use GitHub releases to create tags, you may need to [add a PA token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) for the workflow to be triggered automatically.
- Due to a shortcoming in luarocks.org (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the luarocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.