### PR TITLE
README.md: sample configuration toggle_telescope fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ harpoon:setup({})
 local conf = require("telescope.config").values
 local function toggle_telescope(harpoon_files)
     local file_paths = {}
-    for _, item in ipairs(harpoon_files.items) do
+    for _, item in pairs(harpoon_files.items) do
         table.insert(file_paths, item.value)
     end
 


### PR DESCRIPTION
ipairs doesn't iterate over all the keys in table. It stops when it sees the first nil (removed file). 
If we remove any file in the harpoon:list() we set it to nil. The harpoon's quick_menu ui shows blank for the removed file, however the toggle_telescope ui only lists file till it encounters a nil (discards any items in harpoon_files after some nil).