### PR TITLE
fix: initialize data during Harpoon.setup

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -147,6 +147,7 @@ function Harpoon.setup(self, partial_config)
     ---@diagnostic disable-next-line: param-type-mismatch
     self.config = Config.merge_config(partial_config, self.config)
     self.ui:configure(self.config.settings)
+    self.data = Data.Data:new(self.config)
     self._extensions:emit(Extensions.event_names.SETUP_CALLED, self.config)
 
     ---TODO: should we go through every seen list and update its config?


### PR DESCRIPTION
fixes #577 

Since `Data:new()` was being called before `Harpoon.setup(config)`, it was loading the file for the hash of `vim.loop.cwd()` rather than key. This causes the data file for key to be overwritten when sync is called.

I am having trouble running the tests on a Mac so I have no idea if they are passing.