### PR TITLE
docs(README): telescope remove selected item

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ local function toggle_telescope(harpoon_files)
         }),
         previewer = conf.file_previewer({}),
         sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+            map({ "i", "n" }, "<c-d>", function()
+                local picker = require("telescope.actions.state").get_current_picker(prompt_bufnr)
+                picker:delete_selection(function(selection)
+                    harpoon:list():remove(harpoon:list():get(selection.index))
+                end)
+            end)
+            return true
+        end,
     }):find()
 end
 


### PR DESCRIPTION
Thanks for the awesome plugin!


I derived the code telescope git branch picker:
https://github.com/nvim-telescope/telescope.nvim/blob/dfa230be84a044e7f546a6c2b0a403c739732b86/lua/telescope/builtin/__git.lua#L335-L361

There is one bug that was unable fix tho. It seems that the `harpoon:list():get(selection.index)` is not getting the correct hapoon item. Any idea how to fix this?

Is it also possible swap/rearrange harpoon list items in telescope with a keymap BTW? Maybe I can put that in the docs too?