### PR TITLE
fix: properly handle directory changes

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -100,6 +100,7 @@ end
 ---Resets harpoon data by reading from disk
 function Harpoon:reset()
     self.data = Data.Data:new(self.config)
+    self.lists = {}
 end
 
 function Harpoon:sync()

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -157,25 +157,28 @@ function Harpoon.setup(self, partial_config)
     ---TODO: should we go through every seen list and update its config?
 
     if self.hooks_setup == false then
-        vim.api.nvim_create_autocmd({ "BufLeave", "VimLeavePre", "DirChanged" }, {
-            group = HarpoonGroup,
-            pattern = "*",
-            callback = function(ev)
-                if ev.event == "DirChanged" then
-                    self:reset()
-                end
-                self:_for_each_list(function(list, config)
-                    local fn = config[ev.event]
-                    if fn ~= nil then
-                        fn(ev, list)
+        vim.api.nvim_create_autocmd(
+            { "BufLeave", "VimLeavePre", "DirChanged" },
+            {
+                group = HarpoonGroup,
+                pattern = "*",
+                callback = function(ev)
+                    if ev.event == "DirChanged" then
+                        self:reset()
                     end
+                    self:_for_each_list(function(list, config)
+                        local fn = config[ev.event]
+                        if fn ~= nil then
+                            fn(ev, list)
+                        end
 
-                    if ev.event == "VimLeavePre" then
-                        self:sync()
-                    end
-                end)
-            end,
-        })
+                        if ev.event == "VimLeavePre" then
+                            self:sync()
+                        end
+                    end)
+                end,
+            }
+        )
 
         self.hooks_setup = true
     end

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -97,6 +97,11 @@ function Harpoon:_for_each_list(cb)
     end
 end
 
+---Resets harpoon data by reading from disk
+function Harpoon:reset()
+    self.data = Data.Data:new(self.config)
+end
+
 function Harpoon:sync()
     local key = self.config.settings.key()
     self:_for_each_list(function(list, _, list_name)
@@ -152,10 +157,13 @@ function Harpoon.setup(self, partial_config)
     ---TODO: should we go through every seen list and update its config?
 
     if self.hooks_setup == false then
-        vim.api.nvim_create_autocmd({ "BufLeave", "VimLeavePre" }, {
+        vim.api.nvim_create_autocmd({ "BufLeave", "VimLeavePre", "DirChanged" }, {
             group = HarpoonGroup,
             pattern = "*",
             callback = function(ev)
+                if ev.event == "DirChanged" then
+                    self:reset()
+                end
                 self:_for_each_list(function(list, config)
                     local fn = config[ev.event]
                     if fn ~= nil then


### PR DESCRIPTION
This change clears out the in-memory harpoon data and re-read it from the disk whenever a `DirChanged` event is triggered. This makes sure the in memory data always reflects the harpoon lists for the current working directory.

Fixes #612 
