### PR TITLE
Make wrap around default behavior

### DIFF
--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -299,7 +299,7 @@ end
 ---
 --- @param opts? HarpoonNavOptions
 function HarpoonList:next(opts)
-    opts = opts or {}
+    opts = opts or { ui_nav_wrap = true }
 
     self._index = self._index + 1
     if self._index > self._length then
@@ -316,7 +316,7 @@ end
 ---
 --- @param opts? HarpoonNavOptions
 function HarpoonList:prev(opts)
-    opts = opts or {}
+    opts = opts or { ui_nav_wrap = true }
 
     self._index = self._index - 1
     if self._index < 1 then


### PR DESCRIPTION
In my opinion wrap around should probably be default behavior. If I have 2 or 3 buffers, I don't want to have to remember which is which index and whether I used `next` or `prev` last time I navigated.