### PR TITLE
Fix nav_file column being off by 1

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -195,7 +195,7 @@ function M.nav_file(id)
     vim.api.nvim_set_current_buf(buf_id)
     vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
     if set_row and mark.row and mark.col then
-        vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
+        vim.api.nvim_win_set_cursor(0, { mark.row, mark.col })
         log.debug(
             string.format(
                 "nav_file(): Setting cursor to row: %d, col: %d",


### PR DESCRIPTION
**What issue does it try to solve**
In `create_mark` and `store_offset` `vim.api.nvim_win_get_cursor` returns (1,0)-based cursor position, but `:call cursor()` in `nav_file` expects (1,1)-based one.