### PR TITLE
Telescope - Respect user preference on long file names

### DIFF
--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -5,6 +5,7 @@ local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")
 local conf = require("telescope.config").values
 local harpoon = require("harpoon")
+local utils = require("telescope.utils")
 
 local function filter_empty_string(list)
     local next = {}
@@ -17,7 +18,7 @@ local function filter_empty_string(list)
     return next
 end
 
-local generate_new_finder = function()
+local generate_new_finder = function(opts)
     return finders.new_table({
         results = filter_empty_string(harpoon:list().items),
         entry_maker = function(entry)
@@ -29,17 +30,16 @@ local generate_new_finder = function()
             local displayer = entry_display.create({
                 separator = " - ",
                 items = {
-                    { width = 2 },
-                    { width = 50 },
-                    { remaining = true },
+                    { remaining = true }
                 },
             })
+
             local make_display = function()
                 return displayer({
-                    tostring(entry.index),
-                    line,
+                    utils.transform_path(opts, line),
                 })
             end
+
             return {
                 value = entry,
                 ordinal = line,
@@ -118,7 +118,7 @@ return function(opts)
     pickers
         .new(opts, {
             prompt_title = "harpoon marks",
-            finder = generate_new_finder(),
+            finder = generate_new_finder(opts),
             sorter = conf.generic_sorter(opts),
             previewer = conf.grep_previewer(opts),
             attach_mappings = function(_, map)


### PR DESCRIPTION
In the default provided telescope extension, the file picker can have some visual glitches and issues when displaying long file names. Telescope provides some configuration options for handling displaying long file names, including an option to set `path_display = {"truncate"} ` to right align long file names, so you can see the actual file instead of the preceding directories. More info on this telescope feature here: https://github.com/nvim-telescope/telescope.nvim/issues/895

This fix respects the users choice of display option, and fixes some visual issues I was seeing when using `:Telescope harpoon marks`. Some questions I have about improving the implementation:

1. Since harpoon seems to moving to putting the telescope integration in the hands of a user's configuration file, should we even still be updating the provided Telescope picker?
2. Should we try to reintegrate the harpoon index into the provided picker? (I removed it since it was not set in the table when I called harpoon:list())

Hope this is helpful!

Before:
![Screenshot from 2024-10-10 10-44-26](https://github.com/user-attachments/assets/31a5b585-ea2b-41da-a37b-06de24e5c0a9)

After:
![Screenshot from 2024-10-10 10-43-46](https://github.com/user-attachments/assets/735f5197-e947-4335-b33a-1ef6d5d83b3f)
