### PR TITLE
docs: set `entry_maker` in README's telescope example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,24 @@ harpoon:setup({})
 -- basic telescope configuration
 local conf = require("telescope.config").values
 local function toggle_telescope(harpoon_files)
-    local file_paths = {}
-    for _, item in ipairs(harpoon_files.items) do
-        table.insert(file_paths, item.value)
-    end
-
-    require("telescope.pickers").new({}, {
-        prompt_title = "Harpoon",
-        finder = require("telescope.finders").new_table({
-            results = file_paths,
-        }),
-        previewer = conf.file_previewer({}),
-        sorter = conf.generic_sorter({}),
-    }):find()
+	require("telescope.pickers")
+		.new({}, {
+			prompt_title = "Harpoon",
+			finder = require("telescope.finders").new_table({
+				results = harpoon_files.items,
+				entry_maker = function(item)
+					return {
+						value = item.value,
+						ordinal = item.value,
+						display = item.value,
+						filename = item.value,
+					}
+				end,
+			}),
+			previewer = conf.file_previewer({}),
+			sorter = conf.generic_sorter({}),
+		})
+		:find()
 end
 
 vim.keymap.set("n", "<C-e>", function() toggle_telescope(harpoon:list()) end,


### PR DESCRIPTION
Update README to include an `entry_maker` configuration, enabling Telescope to properly handle plugin-specific buffer paths ("<plugin>://<name>"). Previously, opening such paths after restarting Neovim would result in an empty buffer. In particular, I was running into this issue with [octo.nvim](https://github.com/pwntester/octo.nvim) buffers.