### PR TITLE
Sign column disappearing and leaked treesitter-context

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -114,7 +114,6 @@ function M.get_default_config()
                     bufnr = vim.fn.bufadd(list_item.value)
                 end
                 if not vim.api.nvim_buf_is_loaded(bufnr) then
-                    vim.fn.bufload(bufnr)
                     vim.api.nvim_set_option_value("buflisted", true, {
                         buf = bufnr,
                     })


### PR DESCRIPTION
Deleted line according to issues #639 and #559.
Resolves the problem where navigating to a file with harpoon immediately after opening nvim causes the sign column to disappear and a treesitter-context to appear. The ts-context will persist even after leaving the file.

[bad](https://github.com/user-attachments/assets/e8dda58f-5131-4fa1-8d69-2a9b656af0be)

After fix: sign column returns and ts-context doesn't appear randomly


[good.webm](https://github.com/user-attachments/assets/36f3bc1f-8494-42bd-8946-8e96fba83b5a)


Upon updating to the latest nvim nightly as well as ts-context receiving a [new commit](https://github.com/nvim-treesitter/nvim-treesitter-context/commit/1147c42cf9477701581d1eb31e1735969e21dd06) as I was making this pr: 
the context no longer persists but flashes; the sign column is still missing

https://github.com/user-attachments/assets/86ea9778-6d8e-4cd2-a6a5-f4ee57468eeb

Sorry for the shakey recording. Phone camera slomo was the only way to capture the flashing context