### PR TITLE
Fix Telescope extension line and column numbers

### DIFF
--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -44,8 +44,8 @@ local generate_new_finder = function()
                 value = entry,
                 ordinal = line,
                 display = make_display,
-                lnum = entry.row,
-                col = entry.col,
+                lnum = entry.context.row,
+                col = entry.context.col,
                 filename = entry.value,
             }
         end,


### PR DESCRIPTION
The `entry_maker` function of the Telescope marks extension wasn't copying the line and column number of the marks correctly over to Telescope entries. (It referred to `entry.row` and `entry.col` instead of `entry.context.row` and `entry.context.column`.)