### PR TITLE
fix(mark.lua): support URI buffers (commonly used for custom buffers in neovim plugins)

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -213,6 +213,8 @@ end
 function M.add_file(file_name_or_buf_id)
     filter_filetype()
     local buf_name = get_buf_name(file_name_or_buf_id)
+    -- Support for URI-like buffers. Without this, the "//" will be "/" in the quick menu
+    buf_name = string.gsub(buf_name, "://", ":\\/\\/")
     log.trace("add_file():", buf_name)
 
     if M.valid_index(M.get_index_of(buf_name)) then


### PR DESCRIPTION
I am using `octo.nvim`. It has custom buffers, where it uses a URI path for pull request and issue buffers. When adding it to the quick menu, the `://` in the URI (format: `octo://username/reponame/pull/119`) to a single `/`, meaning it will not go to the correct buffer (because the path will be `octo:/username/reponame/pull/119`. To fix this, escape the `//` in `://` to be `:\/\/`.

