### PR TITLE
Fix: partial_config.settings.key() not working as expected

### DIFF
--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -146,6 +146,7 @@ function Harpoon.setup(self, partial_config)
 
     ---@diagnostic disable-next-line: param-type-mismatch
     self.config = Config.merge_config(partial_config, self.config)
+    self.data = Data.Data:new(self.config)
     self.ui:configure(self.config.settings)
     self._extensions:emit(Extensions.event_names.SETUP_CALLED, self.config)
 


### PR DESCRIPTION
# Context
Currently if you add a custom "key()" function from the config, it is not being picked up by harpoon, because the initialization of the "data" variable is done before the "setup" call.

# What does this PR do?
it re-initializes the data variable during the setup call, so that the custom key function is picked up by harpoon