### PR TITLE
feat: add basic web-devicons support

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -85,7 +85,20 @@ function M.get_default_config()
 
             ---@param list_item HarpoonListItem
             display = function(list_item)
-                return list_item.value
+                local ext = ""
+                for i = #list_item.value, 1, -1 do
+                    if string.byte(list_item.value, i) == string.byte(".") then
+                        ext = list_item.value:sub(i + 1)
+                        break
+                    end
+                end
+
+                local icon = require("nvim-web-devicons").get_icon(
+                    list_item,
+                    ext
+                ) or ""
+
+                return icon .. " " .. list_item.value
             end,
 
             --- the select function is called when a user selects an item from

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -85,6 +85,7 @@ function M.get_default_config()
 
             ---@param list_item HarpoonListItem
             display = function(list_item)
+                local nbsp = "\u{2002}"
                 local icons_loaded, icons_package =
                     pcall(require, "nvim-web-devicons")
 
@@ -102,7 +103,7 @@ function M.get_default_config()
 
                 local icon = icons_package.get_icon(list_item, ext) or ""
 
-                return icon .. " " .. list_item.value
+                return icon .. nbsp .. list_item.value
             end,
 
             --- the select function is called when a user selects an item from

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -101,7 +101,8 @@ function M.get_default_config()
                     end
                 end
 
-                local icon = icons_package.get_icon(list_item, ext) or ""
+                local icon = icons_package.get_icon(list_item.value, ext)
+                    or ""
 
                 return icon .. nbsp .. list_item.value
             end,

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -85,7 +85,7 @@ function M.get_default_config()
 
             ---@param list_item HarpoonListItem
             display = function(list_item)
-                local nbsp = "\u{2002}"
+                local nbsp = "\u{00A0}"
                 local icons_loaded, icons_package =
                     pcall(require, "nvim-web-devicons")
 

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -93,10 +93,14 @@ function M.get_default_config()
                     end
                 end
 
-                local icon = require("nvim-web-devicons").get_icon(
-                    list_item,
-                    ext
-                ) or ""
+                local icons_loaded, icons_package =
+                    pcall(require, "nvim-web-devicons")
+
+                if not icons_loaded then
+                    return list_item.value
+                end
+
+                local icon = icons_package.get_icon(list_item, ext) or ""
 
                 return icon .. " " .. list_item.value
             end,

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -93,16 +93,9 @@ function M.get_default_config()
                     return list_item.value
                 end
 
-                local ext = ""
-                for i = #list_item.value, 1, -1 do
-                    if string.byte(list_item.value, i) == string.byte(".") then
-                        ext = list_item.value:sub(i + 1)
-                        break
-                    end
-                end
-
-                local icon = icons_package.get_icon(list_item.value, ext)
-                    or ""
+                local icon = icons_package.get_icon(
+                    vim.fn.fnamemodify(list_item.value, ":t")
+                ) or ""
 
                 return icon .. nbsp .. list_item.value
             end,

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -85,19 +85,19 @@ function M.get_default_config()
 
             ---@param list_item HarpoonListItem
             display = function(list_item)
+                local icons_loaded, icons_package =
+                    pcall(require, "nvim-web-devicons")
+
+                if not icons_loaded then
+                    return list_item.value
+                end
+
                 local ext = ""
                 for i = #list_item.value, 1, -1 do
                     if string.byte(list_item.value, i) == string.byte(".") then
                         ext = list_item.value:sub(i + 1)
                         break
                     end
-                end
-
-                local icons_loaded, icons_package =
-                    pcall(require, "nvim-web-devicons")
-
-                if not icons_loaded then
-                    return list_item.value
                 end
 
                 local icon = icons_package.get_icon(list_item, ext) or ""

--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -68,12 +68,15 @@ function Builtins.highlight_current_file()
     return {
         UI_CREATE = function(cx)
             for line_number, file in pairs(cx.contents) do
-                -- Searching for first nbsp
-                local nbsp_idx = string.find(file, " ", 1, true)
-                local parsed_file = nbsp_idx and string.sub(file, nbsp_idx + 1)
-                    or file
+                local icons_loaded = pcall(require, "nvim-web-devicons")
 
-                if string.find(cx.current_file, parsed_file, 1, true) then
+                if icons_loaded then
+                    -- Searching for first nbsp
+                    local nbsp_idx = string.find(file, " ", 1, true)
+                    file = nbsp_idx and string.sub(file, nbsp_idx + 1) or file
+                end
+
+                if string.find(cx.current_file, file, 1, true) then
                     -- highlight the harpoon menu line that corresponds to the current buffer
                     vim.api.nvim_buf_add_highlight(
                         cx.bufnr,

--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -68,7 +68,12 @@ function Builtins.highlight_current_file()
     return {
         UI_CREATE = function(cx)
             for line_number, file in pairs(cx.contents) do
-                if string.find(cx.current_file, file, 1, true) then
+                -- Searching for first nbsp
+                local nbsp_idx = string.find(file, " ", 1, true)
+                local parsed_file = nbsp_idx and string.sub(file, nbsp_idx + 1)
+                    or file
+
+                if string.find(cx.current_file, parsed_file, 1, true) then
                     -- highlight the harpoon menu line that corresponds to the current buffer
                     vim.api.nvim_buf_add_highlight(
                         cx.bufnr,

--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -68,11 +68,12 @@ function Builtins.highlight_current_file()
     return {
         UI_CREATE = function(cx)
             for line_number, file in pairs(cx.contents) do
+                local nbsp = "\u{2002}"
                 local icons_loaded = pcall(require, "nvim-web-devicons")
 
                 if icons_loaded then
                     -- Searching for first nbsp
-                    local nbsp_idx = string.find(file, " ", 1, true)
+                    local nbsp_idx = string.find(file, nbsp, 1, true)
                     file = nbsp_idx and string.sub(file, nbsp_idx + 1) or file
                 end
 

--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -68,12 +68,12 @@ function Builtins.highlight_current_file()
     return {
         UI_CREATE = function(cx)
             for line_number, file in pairs(cx.contents) do
-                local nbsp = "\u{2002}"
+                local nbsp = "\u{00A0}"
                 local icons_loaded = pcall(require, "nvim-web-devicons")
 
                 if icons_loaded then
-                    -- Searching for first nbsp
-                    local nbsp_idx = string.find(file, nbsp, 1, true)
+                    -- Searching for first nbsp end position
+                    local _, nbsp_idx = string.find(file, nbsp, 1, true)
                     file = nbsp_idx and string.sub(file, nbsp_idx + 1) or file
                 end
 


### PR DESCRIPTION
Adding basic support for `nvim-web-devicons`

I'm open to any suggestions for improvements. Currently, it will autodetect if `nvim-web-devicons` package is available and load it to use it, otherwise it works as usual. I could also add a flag to enable/disable it if needed.

I haven't added highlight colors for it keeping it as minimalistic as possible to match the Harpoon UI style.

<img width="535" alt="image" src="https://github.com/user-attachments/assets/3c6a0650-0d38-421b-8b96-ae7186861a26" />
