### PR TITLE
refactor: update deprecated vim api code

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ There is quite a bit of behavior you can configure via `harpoon:setup()`
 * `create_list_item`: called when `list:add()` or `list:prepend()` is called.  called with an item, which will be a string, when adding through the ui menu
 * `BufLeave`: this function is called for every list on BufLeave.  if you need custom behavior, this is the place
 * `VimLeavePre`: this function is called for every list on VimLeavePre.
-* `get_root_dir`: used for creating relative paths.  defaults to `vim.loop.cwd()`
+* `get_root_dir`: used for creating relative paths.  defaults to `vim.uv.cwd()`
 
 ### Settings
 Settings can alter the experience of harpoon
@@ -232,7 +232,7 @@ settings = {
     save_on_toggle = false,
     sync_on_ui_close = false,
     key = function()
-        return vim.loop.cwd()
+        return vim.uv.cwd()
     end,
 },
 ```

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -62,7 +62,7 @@ function M.get_default_config()
             sync_on_ui_close = false,
 
             key = function()
-                return vim.loop.cwd()
+                return vim.uv.cwd()
             end,
         },
 
@@ -182,7 +182,7 @@ function M.get_default_config()
             end,
 
             get_root_dir = function()
-                return vim.loop.cwd()
+                return vim.uv.cwd()
             end,
 
             ---@param config HarpoonPartialConfigItem

--- a/lua/harpoon/extensions/init.lua
+++ b/lua/harpoon/extensions/init.lua
@@ -70,13 +70,14 @@ function Builtins.highlight_current_file()
             for line_number, file in pairs(cx.contents) do
                 if string.find(cx.current_file, file, 1, true) then
                     -- highlight the harpoon menu line that corresponds to the current buffer
-                    vim.api.nvim_buf_add_highlight(
+                    vim.api.nvim_buf_set_extmark(
                         cx.bufnr,
-                        -1,
-                        "CursorLineNr",
+                        vim.api.nvim_create_namespace(
+                            "HarpoonHighlightCurrentFile"
+                        ),
                         line_number - 1,
                         0,
-                        -1
+                        { hl_group = "CursorLineNr", end_col = #file }
                     )
                     -- set the position of the cursor in the harpoon menu to the start of the current buffer line
                     vim.api.nvim_win_set_cursor(cx.win_id, { line_number, 0 })


### PR DESCRIPTION
- Updates deprecated `vim` api usages.
- Replaces `vim.loop` for `vim.uv`.
- Replaces `vim.api.nvim_buf_add_highlight` for `vim.api.nvim_buf_set_extmark`.