### PR TITLE
Add active_list to UI_CREATE context object

### DIFF
--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -160,6 +160,7 @@ function HarpoonUI:toggle_quick_menu(list, opts)
         bufnr = bufnr,
         current_file = current_file,
         contents = contents,
+        active_list = list,
     })
 end
 


### PR DESCRIPTION
Add active_list to UI_CREATE context object

In my case i'd like to do something like this:
```lua
harpoon:extend({
  UI_CREATE = function(cx)
    for i = 1, 9 do
      vim.keymap.set("n", "" .. i, function()
        harpoon:list(cx.active_list.name):select(i)
      end, { buffer = cx.bufnr })
    end
  end,
})

```