### PR TITLE
fix: cursor position not set correctly, update cursor position when index exists

### DIFF
--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -251,7 +251,13 @@ function M.get_default_config()
                 M.update_harpoon_item_position(list, arg.buf)
             end,
 
-            autocmds = { "BufLeave" },
+            ---@param arg {buf: number}
+            ---@param list HarpoonList
+            VimLeavePre = function(arg, list)
+                M.update_harpoon_item_position(list, arg.buf)
+            end,
+
+            autocmds = { "BufLeave", "VimLeavePre" },
         },
     }
 end

--- a/lua/harpoon/config.lua
+++ b/lua/harpoon/config.lua
@@ -53,6 +53,38 @@ function M.get_config(config, name)
     return vim.tbl_extend("force", {}, config.default, config[name] or {})
 end
 
+---@param list HarpoonList
+---@param bufnr? integer
+function M.update_harpoon_item_position(list, bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local bufname = normalize_path(
+        vim.api.nvim_buf_get_name(bufnr),
+        list.config.get_root_dir()
+    )
+    local item = list:get_by_value(bufname)
+
+    if item then
+        local pos = vim.api.nvim_win_get_cursor(0)
+
+        Logger:log(
+            "config_default#BufLeave updating position",
+            bufnr,
+            bufname,
+            item,
+            "to position",
+            pos
+        )
+
+        item.context.row = pos[1]
+        item.context.col = pos[2]
+
+        Extensions.extensions:emit(
+            Extensions.event_names.POSITION_UPDATED,
+            item
+        )
+    end
+end
+
 ---@return HarpoonConfig
 function M.get_default_config()
     return {
@@ -107,9 +139,8 @@ function M.get_default_config()
                 options = options or {}
 
                 local bufnr = vim.fn.bufnr(to_exact_name(list_item.value))
-                local set_position = false
+
                 if bufnr == -1 then -- must create a buffer!
-                    set_position = true
                     -- bufnr = vim.fn.bufnr(list_item.value, true)
                     bufnr = vim.fn.bufadd(list_item.value)
                 end
@@ -130,38 +161,37 @@ function M.get_default_config()
 
                 vim.api.nvim_set_current_buf(bufnr)
 
-                if set_position then
-                    local lines = vim.api.nvim_buf_line_count(bufnr)
+                -- position should always be set when selected
+                local lines = vim.api.nvim_buf_line_count(bufnr)
 
-                    local edited = false
-                    if list_item.context.row > lines then
-                        list_item.context.row = lines
-                        edited = true
-                    end
+                local edited = false
+                if list_item.context.row > lines then
+                    list_item.context.row = lines
+                    edited = true
+                end
 
-                    local row = list_item.context.row
-                    local row_text =
-                        vim.api.nvim_buf_get_lines(0, row - 1, row, false)
-                    local col = #row_text[1]
+                local row = list_item.context.row
+                local row_text =
+                    vim.api.nvim_buf_get_lines(0, row - 1, row, false)
+                local col = #row_text[1]
 
-                    if list_item.context.col > col then
-                        list_item.context.col = col
-                        edited = true
-                    end
+                if list_item.context.col > col then
+                    list_item.context.col = col
+                    edited = true
+                end
 
-                    vim.api.nvim_win_set_cursor(0, {
-                        list_item.context.row or 1,
-                        list_item.context.col or 0,
-                    })
+                vim.api.nvim_win_set_cursor(0, {
+                    list_item.context.row or 1,
+                    list_item.context.col or 0,
+                })
 
-                    if edited then
-                        Extensions.extensions:emit(
-                            Extensions.event_names.POSITION_UPDATED,
-                            {
-                                list_item = list_item,
-                            }
-                        )
-                    end
+                if edited then
+                    Extensions.extensions:emit(
+                        Extensions.event_names.POSITION_UPDATED,
+                        {
+                            list_item = list_item,
+                        }
+                    )
                 end
 
                 Extensions.extensions:emit(Extensions.event_names.NAVIGATE, {
@@ -218,33 +248,7 @@ function M.get_default_config()
             ---@param arg {buf: number}
             ---@param list HarpoonList
             BufLeave = function(arg, list)
-                local bufnr = arg.buf
-                local bufname = normalize_path(
-                    vim.api.nvim_buf_get_name(bufnr),
-                    list.config.get_root_dir()
-                )
-                local item = list:get_by_value(bufname)
-
-                if item then
-                    local pos = vim.api.nvim_win_get_cursor(0)
-
-                    Logger:log(
-                        "config_default#BufLeave updating position",
-                        bufnr,
-                        bufname,
-                        item,
-                        "to position",
-                        pos
-                    )
-
-                    item.context.row = pos[1]
-                    item.context.col = pos[2]
-
-                    Extensions.extensions:emit(
-                        Extensions.event_names.POSITION_UPDATED,
-                        item
-                    )
-                end
+                M.update_harpoon_item_position(list, arg.buf)
             end,
 
             autocmds = { "BufLeave" },

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -1,7 +1,7 @@
 local Logger = require("harpoon.logger")
 local utils = require("harpoon.utils")
 local Extensions = require("harpoon.extensions")
-local config = require("harpoon.config")
+local harpoon_config = require("harpoon.config")
 
 local function guess_length(arr)
     local last_known = #arr
@@ -157,7 +157,7 @@ function HarpoonList:add(item)
             { list = self, item = item, idx = idx }
         )
     else
-        config.update_harpoon_item_position(self)
+        harpoon_config.update_harpoon_item_position(self)
     end
 
     return self
@@ -179,7 +179,7 @@ function HarpoonList:prepend(item)
             { list = self, item = item, idx = 1 }
         )
     else
-        config.update_harpoon_item_position(self)
+        harpoon_config.update_harpoon_item_position(self)
     end
 
     return self

--- a/lua/harpoon/list.lua
+++ b/lua/harpoon/list.lua
@@ -1,6 +1,7 @@
 local Logger = require("harpoon.logger")
 local utils = require("harpoon.utils")
 local Extensions = require("harpoon.extensions")
+local config = require("harpoon.config")
 
 local function guess_length(arr)
     local last_known = #arr
@@ -155,6 +156,8 @@ function HarpoonList:add(item)
             Extensions.event_names.ADD,
             { list = self, item = item, idx = idx }
         )
+    else
+        config.update_harpoon_item_position(self)
     end
 
     return self
@@ -175,6 +178,8 @@ function HarpoonList:prepend(item)
             Extensions.event_names.ADD,
             { list = self, item = item, idx = 1 }
         )
+    else
+        config.update_harpoon_item_position(self)
     end
 
     return self


### PR DESCRIPTION
I am using NvChad and I really like this plugin, but I found a couple of bugs:

1. When closing a buffer via :bd (without quitting Neovim) and then navigating back to the same buffer with Harpoon, the cursor position is reset to {1, 0}.
2. The cursor position is not updated when the buffer index already exists.

So I made some changes to fix these problems, and now it works fine.

fix #533 #441 , I think manually updating the cursor position is better than saving the position when quitting Neovim.