### PR TITLE
fix lazy.nvim install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ use {
 ```
 * install using [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
-{
+return {
     "ThePrimeagen/harpoon",
     branch = "harpoon2",
     dependencies = { "nvim-lua/plenary.nvim" }


### PR DESCRIPTION
there's a missing `return` keyword that prevents this from being a drop-in file in lua/plugins/