### PR TITLE
feat: highlight the directory part of filepaths and expose a couple of highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ harpoon:extend(harpoon_extensions.builtins.highlight_current_file())
 ```
 
 ### Highlight Groups
+*   Use `HarpoonFile` to highlight the *file* part of a path in the harpoon buffer
+*   Use `HarpoonDirectory` to highlight the *directory* part of a path in the harpoon buffer
+
 TODO: Fill in the idea that we will emit out window information
 
 ### Logger

--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -82,7 +82,7 @@ function M.setup_autocmds_and_keymaps(bufnr)
         end,
     })
 
-    vim.api.nvim_set_hl(0, "harpoonDirectory", { fg = "#8091A0" })
+    vim.api.nvim_set_hl(0, "HarpoonDirectory", { fg = "#8091A0" })
 end
 
 ---@param bufnr number

--- a/lua/harpoon/buffer.lua
+++ b/lua/harpoon/buffer.lua
@@ -81,6 +81,8 @@ function M.setup_autocmds_and_keymaps(bufnr)
             require("harpoon").ui:toggle_quick_menu()
         end,
     })
+
+    vim.api.nvim_set_hl(0, "harpoonDirectory", { fg = "#8091A0" })
 end
 
 ---@param bufnr number

--- a/syntax/harpoon.vim
+++ b/syntax/harpoon.vim
@@ -1,0 +1,9 @@
+syntax case ignore
+" A file is anything except a `/` at the end of the string
+syntax match HarpoonFile @[^/]\+$@
+
+" A directory is anything that ends with a `/`
+syntax match HarpoonDirectory @^.\+/@
+
+highlight default link HarpoonDirectory Directory
+


### PR DESCRIPTION
Addresses #688.

Adds a syntax file for the `harpoon` filetype. This basically defines 2 regexes which detect the directory/file parts of filepaths and add highlight groups for both. These new hl groups are `HarpoonFile` and `HarpoonDirectory`, and the latter is linked to the normal `Directory` hl group.

I set the default highlight for `HarpoonDirectory` to `#8091A0`. This gives colours following those used by Folke's `Snacks.picker`:

<img width="432" height="152" alt="Screenshot 2025-08-31 at 23 14 24" src="https://github.com/user-attachments/assets/d11d5393-dacd-4970-9fc6-9bb4e39bde50" />

Hope this looks okay! Lmk if you'd like anything changed. 

Many thanks 🙏