### PR TITLE
docs: fix README plugin name casing for packer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tmux windows, or dream up your own custom action and execute with a single key
 ```lua
 use "nvim-lua/plenary.nvim" -- don't forget to add this one if you don't have it yet!
 use {
-    "ThePrimeagen/harpoon",
+    "theprimeagen/harpoon",
     branch = "harpoon2",
     requires = { {"nvim-lua/plenary.nvim"} }
 }


### PR DESCRIPTION
The README example for using Harpoon with packer had `ThePrimeagen/harpoon`
instead of the correct lowercase `theprimeagen/harpoon`. 

for some reason this was causing install issues until i changed it to lowercase which Prime has in his video: 0 to LSP.
I know packer is dead, but this could help people still following his tut.


Fixes issue #699

