### PR TITLE
chore(workflows): fix the packages download path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,38 +3,42 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  unit_tests:
-    name: unit tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            rev: nightly/nvim-linux64.tar.gz
-          - os: ubuntu-22.04
-            rev: v0.9.0/nvim-linux64.tar.gz
-    steps:
-      - uses: actions/checkout@v3
-      - run: date +%F > todays-date
-      - name: Restore from todays cache
-        uses: actions/cache@v3
-        with:
-          path: _neovim
-          key: ${{ runner.os }}-${{ matrix.rev }}-${{ hashFiles('todays-date') }}
+    unit_tests:
+        name: unit tests
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - os: ubuntu-22.04
+                      rev: nightly/nvim-linux-x86_64.tar.gz
+                    - os: ubuntu-22.04
+                      rev: v0.11.5/nvim-linux-x86_64.tar.gz
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Prepare
-        run: |
-          test -d _neovim || {
-            mkdir -p _neovim
-            curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
-          }
-      - name: Dependencies
-        run: |
-            git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
-            ln -s "$(pwd)" ~/.local/share/nvim/site/pack/vendor/start
-      - name: Run tests
-        run: |
-          export PATH="${PWD}/_neovim/bin:${PATH}"
-          nvim --version
-          make test
+            - run: date +%F > todays-date
+
+            - name: Restore from todays cache
+              uses: actions/cache@v3
+              with:
+                  path: _neovim
+                  key: ${{ runner.os }}-${{ matrix.rev }}-${{ hashFiles('todays-date') }}
+
+            - name: Prepare
+              run: |
+                  test -d _neovim || {
+                    mkdir -p _neovim
+                    curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+                  }
+
+            - name: Dependencies
+              run: |
+                  git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+                  ln -s "$(pwd)" ~/.local/share/nvim/site/pack/vendor/start
+
+            - name: Run tests
+              run: |
+                  export PATH="${PWD}/_neovim/bin:${PATH}"
+                  nvim --version
+                  make test


### PR DESCRIPTION
## Summary
Fix the CI workflow so that it doesn't fail downloading packages

## Changes
* switch to new zip format available in GH packages (https://github.com/neovim/neovim/releases/tag/v0.11.5)
* move to newest nvim version for versioned download

## Reason
Since I had the same problem with my plugin, because I shamelessly copied your workflows - here are the results before and after.

Before:
<img width="506" height="535" alt="image" src="https://github.com/user-attachments/assets/66ea026a-783a-4829-987f-4db7c52214bd" />
<img width="488" height="195" alt="image" src="https://github.com/user-attachments/assets/bc394b1f-b32b-4060-84de-24e2af2ceef4" />

After:
<img width="706" height="282" alt="image" src="https://github.com/user-attachments/assets/d597250c-ca04-47eb-adc8-412d38e3e97d" />
