### PR TITLE
test

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+---
+name: Bug report
+about: Found something wrong with Harpoon2?
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**WARNING**
+If this is about Harpoon1, the issue will be closed.  All support and everything of harpoon1 will be frozen on `master` until 4/20 or 6/9 and then harpoon2 will become master
+
+Please use `harpoon2` for branch
+---------------

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**What issue are you having that you need harpoon to solve?**
+
+**Why doesn't the current config help?**
+
+**What proposed api changes are you suggesting?**

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Result:
 ![tabline](https://i.imgur.com/8i8mKJD.png)
 
 ## ⇁ Social
-For questions about Harpoon, there's a #harpoon channel on [the Primagen's Discord](https://discord.gg/theprimeagen) server.
+For questions about Harpoon, there's a #harpoon channel on [the Primeagen's Discord](https://discord.gg/theprimeagen) server.
 * [Discord](https://discord.gg/theprimeagen)
 * [Twitch](https://www.twitch.tv/theprimeagen)
 * [Twitter](https://twitter.com/ThePrimeagen)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ global_settings = {
 
     -- set marks specific to each git branch inside git repository
     mark_branch = false,
+
+    -- enable tabline with harpoon marks
+    tabline = false,
+    tabline_prefix = "   ",
+    tabline_suffix = "   ",
 }
 ```
 
@@ -207,6 +212,29 @@ require("harpoon").setup({
     }
 })
 ```
+
+
+#### Tabline
+
+By default, the tabline will use the default theme of your theme.  You can customize by editing the following highlights:
+
+* HarpoonInactive
+* HarpoonActive
+* HarpoonNumberActive
+* HarpoonNumberInactive
+
+Example to make it cleaner:
+
+```lua
+vim.cmd('highlight! HarpoonInactive guibg=NONE guifg=#63698c')
+vim.cmd('highlight! HarpoonActive guibg=NONE guifg=white')
+vim.cmd('highlight! HarpoonNumberActive guibg=NONE guifg=#7aa2f7')
+vim.cmd('highlight! HarpoonNumberInactive guibg=NONE guifg=#7aa2f7')
+vim.cmd('highlight! TabLineFill guibg=NONE guifg=white')
+```
+
+Result: 
+![tabline](https://i.imgur.com/8i8mKJD.png) 
 
 ## ⇁ Social
 For questions about Harpoon, there's a #harpoon channel on [the Primagen's Discord](https://discord.gg/theprimeagen) server.  

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ you can also cycle the list in both directions
 :lua require("harpoon.ui").nav_next()                   -- navigates to next mark
 :lua require("harpoon.ui").nav_prev()                   -- navigates to previous mark
 ```
+from the quickmenu, open a file in: 
+a vertical split with control+v,
+a horizontal split with control+x, 
+a new tab with control+t
 
 ### Terminal Navigation
 this works like file navigation except that if there is no terminal at the specified index

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 <div align="center">
 
+## ⇁  HARPOON 2
+This is a deprecated and all future changes will be to the branch `harpoon2`.
+
+[Harpoon 2](https://github.com/ThePrimeagen/harpoon/tree/harpoon2)
+
+**STATUS**: Merging into mainline April 20th or June 9th (nice)
+
+-------------------------------
+# Legacy Harpoon README
+
 # Harpoon
 ##### Getting you where you want with the fewest keystrokes.
 
@@ -9,7 +19,6 @@
 
 ![Harpoon](harpoon.png)
 -- image provided by **Bob Rust**
-
 
 ## ⇁  WIP
 This is not fully baked, though used by several people. If you experience any
@@ -65,9 +74,9 @@ you can also cycle the list in both directions
 :lua require("harpoon.ui").nav_next()                   -- navigates to next mark
 :lua require("harpoon.ui").nav_prev()                   -- navigates to previous mark
 ```
-from the quickmenu, open a file in: 
+from the quickmenu, open a file in:
 a vertical split with control+v,
-a horizontal split with control+x, 
+a horizontal split with control+x,
 a new tab with control+t
 
 ### Terminal Navigation
@@ -233,11 +242,11 @@ vim.cmd('highlight! HarpoonNumberInactive guibg=NONE guifg=#7aa2f7')
 vim.cmd('highlight! TabLineFill guibg=NONE guifg=white')
 ```
 
-Result: 
-![tabline](https://i.imgur.com/8i8mKJD.png) 
+Result:
+![tabline](https://i.imgur.com/8i8mKJD.png)
 
 ## ⇁ Social
-For questions about Harpoon, there's a #harpoon channel on [the Primagen's Discord](https://discord.gg/theprimeagen) server.  
+For questions about Harpoon, there's a #harpoon channel on [the Primagen's Discord](https://discord.gg/theprimeagen) server.
 * [Discord](https://discord.gg/theprimeagen)
 * [Twitch](https://www.twitch.tv/theprimeagen)
 * [Twitter](https://twitter.com/ThePrimeagen)

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -15,7 +15,7 @@ local the_primeagen_harpoon = vim.api.nvim_create_augroup(
     { clear = true }
 )
 
-vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
+vim.api.nvim_create_autocmd({ "BufLeave", "VimLeave" }, {
     callback = function()
         require("harpoon.mark").store_offset()
     end,

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -20,6 +20,38 @@ vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
     group = the_primeagen_harpoon,
 })
 
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = "harpoon",
+    group = the_primeagen_harpoon,
+
+    callback = function()
+        -- Open harpoon file choice in useful ways
+        --
+        -- vertical split (control+v)
+        vim.keymap.set("n", "<C-V>", function()
+            local curline = vim.api.nvim_get_current_line()
+            local working_directory = vim.fn.getcwd() .. "/"
+            vim.cmd("vs")
+            vim.cmd("e " .. working_directory .. curline)
+        end, { buffer=true, noremap = true, silent = true })
+
+        -- horizontal split (control+x)
+        vim.keymap.set("n", "<C-x>", function()
+            local curline = vim.api.nvim_get_current_line()
+            local working_directory = vim.fn.getcwd() .. "/"
+            vim.cmd("sp")
+            vim.cmd("e " .. working_directory .. curline)
+        end, { buffer=true, noremap = true, silent = true })
+
+        -- new tab (control+t)
+        vim.keymap.set("n", "<C-t>", function()
+            local curline = vim.api.nvim_get_current_line()
+            local working_directory = vim.fn.getcwd() .. "/"
+            vim.cmd("tabnew")
+            vim.cmd("e " .. working_directory .. curline)
+        end, { buffer=true, noremap = true, silent = true })
+    end
+})
 --[[
 {
     projects = {

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -10,8 +10,10 @@ local cache_config = string.format("%s/harpoon.json", data_path)
 
 local M = {}
 
-local the_primeagen_harpoon =
-    vim.api.nvim_create_augroup("THE_PRIMEAGEN_HARPOON", { clear = true })
+local the_primeagen_harpoon = vim.api.nvim_create_augroup(
+    "THE_PRIMEAGEN_HARPOON",
+    { clear = true }
+)
 
 vim.api.nvim_create_autocmd({ "BufLeave, VimLeave" }, {
     callback = function()
@@ -33,7 +35,7 @@ vim.api.nvim_create_autocmd("FileType", {
             local working_directory = vim.fn.getcwd() .. "/"
             vim.cmd("vs")
             vim.cmd("e " .. working_directory .. curline)
-        end, { buffer=true, noremap = true, silent = true })
+        end, { buffer = true, noremap = true, silent = true })
 
         -- horizontal split (control+x)
         vim.keymap.set("n", "<C-x>", function()
@@ -41,7 +43,7 @@ vim.api.nvim_create_autocmd("FileType", {
             local working_directory = vim.fn.getcwd() .. "/"
             vim.cmd("sp")
             vim.cmd("e " .. working_directory .. curline)
-        end, { buffer=true, noremap = true, silent = true })
+        end, { buffer = true, noremap = true, silent = true })
 
         -- new tab (control+t)
         vim.keymap.set("n", "<C-t>", function()
@@ -49,8 +51,8 @@ vim.api.nvim_create_autocmd("FileType", {
             local working_directory = vim.fn.getcwd() .. "/"
             vim.cmd("tabnew")
             vim.cmd("e " .. working_directory .. curline)
-        end, { buffer=true, noremap = true, silent = true })
-    end
+        end, { buffer = true, noremap = true, silent = true })
+    end,
 })
 --[[
 {

--- a/lua/harpoon/init.lua
+++ b/lua/harpoon/init.lua
@@ -210,6 +210,9 @@ function M.setup(config)
             ["tmux_autoclose_windows"] = false,
             ["excluded_filetypes"] = { "harpoon" },
             ["mark_branch"] = false,
+            ["tabline"] = false,
+            ["tabline_suffix"] = "   ",
+            ["tabline_prefix"] = "   ",
         },
     }, expand_dir(c_config), expand_dir(u_config), expand_dir(config))
 
@@ -217,7 +220,12 @@ function M.setup(config)
     -- an object for vim.loop.cwd()
     ensure_correct_config(complete_config)
 
+    if complete_config.tabline then
+        require("harpoon.tabline").setup(complete_config)
+    end
+
     HarpoonConfig = complete_config
+
     log.debug("setup(): Complete config", HarpoonConfig)
     log.trace("setup(): log_key", Dev.get_log_key())
 end

--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -11,8 +11,15 @@ local callbacks = {}
 -- need one event emitted
 local function emit_changed()
     log.trace("_emit_changed()")
-    if harpoon.get_global_settings().save_on_change then
+
+    local global_settings = harpoon.get_global_settings()
+
+    if global_settings.save_on_change then
         harpoon.save()
+    end
+
+    if global_settings.tabline then
+        vim.cmd("redrawt")
     end
 
     if not callbacks["changed"] then

--- a/lua/harpoon/tabline.lua
+++ b/lua/harpoon/tabline.lua
@@ -32,20 +32,21 @@ end
 
 function M.setup(opts)
     function _G.tabline()
-        local original_tabs = require('harpoon').get_mark_config().marks
-        local tabs = shorten_filenames(original_tabs)
+        local tabs = shorten_filenames(require('harpoon').get_mark_config().marks)
         local tabline = ''
 
-        for i, tab in ipairs(original_tabs) do
-            local is_current = string.match(vim.fn.bufname(), tab.filename) or vim.fn.bufname() == tab.filename
+        local index = require('harpoon.mark').get_index_of(vim.fn.bufname())
+
+        for i, tab in ipairs(tabs) do
+            local is_current = i == index
 
             local label
 
-            if tabs[i].filename == "" or tabs[i].filename == "(empty)" then
+            if tab.filename == "" or tab.filename == "(empty)" then
                 label = "(empty)"
                 is_current = false
             else
-                label = tabs[i].filename
+                label = tab.filename
             end
 
 
@@ -58,6 +59,7 @@ function M.setup(opts)
             end
 
             tabline = tabline .. label .. (opts.tabline_suffix or '   ') .. '%*'
+
             if i < #tabs then
                 tabline = tabline .. '%T'
             end

--- a/lua/harpoon/tabline.lua
+++ b/lua/harpoon/tabline.lua
@@ -39,7 +39,14 @@ function M.setup(opts)
         for i, tab in ipairs(original_tabs) do
             local is_current = string.match(vim.fn.bufname(), tab.filename) or vim.fn.bufname() == tab.filename
 
-            local label = tabs[i].filename
+            local label
+
+            if tabs[i].filename == "" or tabs[i].filename == "(empty)" then
+                label = "(empty)"
+                is_current = false
+            else
+                label = tabs[i].filename
+            end
 
 
             if is_current then

--- a/lua/harpoon/tabline.lua
+++ b/lua/harpoon/tabline.lua
@@ -1,0 +1,84 @@
+local Dev = require("harpoon.dev")
+local log = Dev.log
+
+local M = {}
+
+local function get_color(group, attr)
+    return vim.fn.synIDattr(vim.fn.synIDtrans(vim.fn.hlID(group)), attr)
+end
+
+
+local function shorten_filenames(filenames)
+    local shortened = {}
+
+    local counts = {}
+    for _, file in ipairs(filenames) do
+        local name = vim.fn.fnamemodify(file.filename, ":t")
+        counts[name] = (counts[name] or 0) + 1
+    end
+
+    for _, file in ipairs(filenames) do
+        local name = vim.fn.fnamemodify(file.filename, ":t")
+
+        if counts[name] == 1 then
+            table.insert(shortened, { filename = vim.fn.fnamemodify(name, ":t") })
+        else
+            table.insert(shortened, { filename = file.filename })
+        end
+    end
+
+    return shortened
+end
+
+function M.setup(opts)
+    function _G.tabline()
+        local original_tabs = require('harpoon').get_mark_config().marks
+        local tabs = shorten_filenames(original_tabs)
+        local tabline = ''
+
+        for i, tab in ipairs(original_tabs) do
+            local is_current = string.match(vim.fn.bufname(), tab.filename) or vim.fn.bufname() == tab.filename
+
+            local label = tabs[i].filename
+
+
+            if is_current then
+                tabline = tabline ..
+                    '%#HarpoonNumberActive#' .. (opts.tabline_prefix or '   ') .. i .. ' %*' .. '%#HarpoonActive#'
+            else
+                tabline = tabline ..
+                    '%#HarpoonNumberInactive#' .. (opts.tabline_prefix or '   ') .. i .. ' %*' .. '%#HarpoonInactive#'
+            end
+
+            tabline = tabline .. label .. (opts.tabline_suffix or '   ') .. '%*'
+            if i < #tabs then
+                tabline = tabline .. '%T'
+            end
+        end
+
+        return tabline
+    end
+
+    vim.opt.showtabline = 2
+
+    vim.o.tabline = '%!v:lua.tabline()'
+
+    vim.api.nvim_create_autocmd("ColorScheme", {
+        group = vim.api.nvim_create_augroup("harpoon", { clear = true }),
+        pattern = { "*" },
+        callback = function()
+            local color = get_color('HarpoonActive', 'bg#')
+
+            if (color == "" or color == nil) then
+                vim.api.nvim_set_hl(0, "HarpoonInactive", { link = "Tabline" })
+                vim.api.nvim_set_hl(0, "HarpoonActive", { link = "TablineSel" })
+                vim.api.nvim_set_hl(0, "HarpoonNumberActive", { link = "TablineSel" })
+                vim.api.nvim_set_hl(0, "HarpoonNumberInactive", { link = "Tabline" })
+            end
+        end,
+    })
+
+    log.debug("setup(): Tabline Setup", opts)
+end
+
+return M

--- a/lua/harpoon/tmux.lua
+++ b/lua/harpoon/tmux.lua
@@ -7,8 +7,10 @@ local M = {}
 local tmux_windows = {}
 
 if global_config.tmux_autoclose_windows then
-    local harpoon_tmux_group =
-        vim.api.nvim_create_augroup("HARPOON_TMUX", { clear = true })
+    local harpoon_tmux_group = vim.api.nvim_create_augroup(
+        "HARPOON_TMUX",
+        { clear = true }
+    )
 
     vim.api.nvim_create_autocmd("VimLeave", {
         callback = function()

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -77,6 +77,19 @@ function M.toggle_quick_menu()
         return
     end
 
+    local curr_file = utils.normalize_path(vim.api.nvim_buf_get_name(0))
+    vim.cmd(
+        string.format(
+            "autocmd Filetype harpoon " ..
+                "let path = '%s' | call clearmatches() | " ..
+                -- move the cursor to the line containing the current filename
+                "call search('\\V'.path.'\\$') | " ..
+                -- add a hl group to that line
+                "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
+            curr_file:gsub("\\", "\\\\")
+        )
+    )
+
     local win_info = create_window()
     local contents = {}
     local global_config = harpoon.get_global_settings()

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -180,6 +180,8 @@ function M.nav_file(id)
     local buf_id = get_or_create_buffer(filename)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 
+    local old_bufnr = vim.api.nvim_get_current_buf()
+
     vim.api.nvim_set_current_buf(buf_id)
     vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
     if set_row and mark.row and mark.col then
@@ -191,6 +193,14 @@ function M.nav_file(id)
                 mark.col
             )
         )
+    end
+
+    local old_bufinfo = vim.fn.getbufinfo(old_bufnr)[1]
+    local no_name = old_bufinfo.name == ""
+    local one_line = old_bufinfo.linecount == 1
+    local unchanged = old_bufinfo.changed == 0
+    if no_name and one_line and unchanged then
+        vim.api.nvim_buf_delete(old_bufnr, {})
     end
 end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -173,10 +173,7 @@ function M.nav_file(id)
     end
 
     local mark = Marked.get_marked_file(idx)
-    local filename = mark.filename
-    if filename:sub(1, 1) ~= "/" then
-        filename = vim.loop.cwd() .. "/" .. mark.filename
-    end
+    local filename = vim.fs.normalize(mark.filename)
     local buf_id = get_or_create_buffer(filename)
     local set_row = not vim.api.nvim_buf_is_loaded(buf_id)
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -205,7 +205,7 @@ function M.nav_file(id)
         )
     end
 
-    local old_bufinfo = vim.fn.getbufinfo(old_bufnr);
+    local old_bufinfo = vim.fn.getbufinfo(old_bufnr)
     if type(old_bufinfo) == "table" and #old_bufinfo >= 1 then
         old_bufinfo = old_bufinfo[1]
         local no_name = old_bufinfo.name == ""

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -206,7 +206,7 @@ function M.nav_file(id)
     end
 
     local old_bufinfo = vim.fn.getbufinfo(old_bufnr);
-    if type(old_bufinfo) ~= "table" and #old_bufinfo >= 1 then
+    if type(old_bufinfo) == "table" and #old_bufinfo >= 1 then
         old_bufinfo = old_bufinfo[1]
         local no_name = old_bufinfo.name == ""
         local one_line = old_bufinfo.linecount == 1

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -205,12 +205,15 @@ function M.nav_file(id)
         )
     end
 
-    local old_bufinfo = vim.fn.getbufinfo(old_bufnr)[1]
-    local no_name = old_bufinfo.name == ""
-    local one_line = old_bufinfo.linecount == 1
-    local unchanged = old_bufinfo.changed == 0
-    if no_name and one_line and unchanged then
-        vim.api.nvim_buf_delete(old_bufnr, {})
+    local old_bufinfo = vim.fn.getbufinfo(old_bufnr);
+    if type(old_bufinfo) ~= "table" and #old_bufinfo >= 1 then
+        old_bufinfo = old_bufinfo[1]
+        local no_name = old_bufinfo.name == ""
+        local one_line = old_bufinfo.linecount == 1
+        local unchanged = old_bufinfo.changed == 0
+        if no_name and one_line and unchanged then
+            vim.api.nvim_buf_delete(old_bufnr, {})
+        end
     end
 end
 

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -80,12 +80,12 @@ function M.toggle_quick_menu()
     local curr_file = utils.normalize_path(vim.api.nvim_buf_get_name(0))
     vim.cmd(
         string.format(
-            "autocmd Filetype harpoon " ..
-                "let path = '%s' | call clearmatches() | " ..
+            "autocmd Filetype harpoon "
+                .. "let path = '%s' | call clearmatches() | "
                 -- move the cursor to the line containing the current filename
-                "call search('\\V'.path.'\\$') | " ..
+                .. "call search('\\V'.path.'\\$') | "
                 -- add a hl group to that line
-                "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
+                .. "call matchadd('HarpoonCurrentFile', '\\V'.path.'\\$')",
             curr_file:gsub("\\", "\\\\")
         )
     )

--- a/lua/harpoon/ui.lua
+++ b/lua/harpoon/ui.lua
@@ -195,7 +195,7 @@ function M.nav_file(id)
     vim.api.nvim_set_current_buf(buf_id)
     vim.api.nvim_buf_set_option(buf_id, "buflisted", true)
     if set_row and mark.row and mark.col then
-        vim.cmd(string.format(":call cursor(%d, %d)", mark.row, mark.col))
+        vim.api.nvim_win_set_cursor(0, { mark.row, mark.col })
         log.debug(
             string.format(
                 "nav_file(): Setting cursor to row: %d, col: %d",

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -38,14 +38,16 @@ function M.get_os_command_output(cmd, cwd)
     end
     local command = table.remove(cmd, 1)
     local stderr = {}
-    local stdout, ret = Job:new({
-        command = command,
-        args = cmd,
-        cwd = cwd,
-        on_stderr = function(_, data)
-            table.insert(stderr, data)
-        end,
-    }):sync()
+    local stdout, ret = Job
+        :new({
+            command = command,
+            args = cmd,
+            cwd = cwd,
+            on_stderr = function(_, data)
+                table.insert(stderr, data)
+            end,
+        })
+        :sync()
     return stdout, ret, stderr
 end
 

--- a/lua/harpoon/utils.lua
+++ b/lua/harpoon/utils.lua
@@ -11,14 +11,25 @@ function M.project_key()
 end
 
 function M.branch_key()
-    -- `git branch --show-current` requires Git v2.22.0+ so going with more
-    -- widely available command
-    local branch = M.get_os_command_output({
-        "git",
-        "rev-parse",
-        "--abbrev-ref",
-        "HEAD",
-    })[1]
+    local branch
+
+    -- use tpope's fugitive for faster branch name resolution if available
+    if vim.fn.exists("*FugitiveHead") == 1 then
+        branch = vim.fn["FugitiveHead"]()
+        -- return "HEAD" for parity with `git rev-parse` in detached head state
+        if #branch == 0 then
+            branch = "HEAD"
+        end
+    else
+        -- `git branch --show-current` requires Git v2.22.0+ so going with more
+        -- widely available command
+        branch = M.get_os_command_output({
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        })[1]
+    end
 
     if branch then
         return vim.loop.cwd() .. "-" .. branch

--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -7,10 +7,11 @@ local conf = require("telescope.config").values
 local harpoon = require("harpoon")
 local harpoon_mark = require("harpoon.mark")
 
-local function filter_empty_string(list)
+local function prepare_results(list)
     local next = {}
     for idx = 1, #list do
         if list[idx].filename ~= "" then
+            list[idx].index = idx
             table.insert(next, list[idx])
         end
     end
@@ -20,7 +21,7 @@ end
 
 local generate_new_finder = function()
     return finders.new_table({
-        results = filter_empty_string(harpoon.get_mark_config().marks),
+        results = prepare_results(harpoon.get_mark_config().marks),
         entry_maker = function(entry)
             local line = entry.filename .. ":" .. entry.row .. ":" .. entry.col
             local displayer = entry_display.create({

--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -51,8 +51,9 @@ local generate_new_finder = function()
 end
 
 local delete_harpoon_mark = function(prompt_bufnr)
-    local confirmation =
-        vim.fn.input(string.format("Delete current mark(s)? [y/n]: "))
+    local confirmation = vim.fn.input(
+        string.format("Delete current mark(s)? [y/n]: ")
+    )
     if
         string.len(confirmation) == 0
         or string.sub(string.lower(confirmation), 0, 1) ~= "y"
@@ -113,23 +114,21 @@ end
 return function(opts)
     opts = opts or {}
 
-    pickers
-        .new(opts, {
-            prompt_title = "harpoon marks",
-            finder = generate_new_finder(),
-            sorter = conf.generic_sorter(opts),
-            previewer = conf.grep_previewer(opts),
-            attach_mappings = function(_, map)
-                map("i", "<c-d>", delete_harpoon_mark)
-                map("n", "<c-d>", delete_harpoon_mark)
+    pickers.new(opts, {
+        prompt_title = "harpoon marks",
+        finder = generate_new_finder(),
+        sorter = conf.generic_sorter(opts),
+        previewer = conf.grep_previewer(opts),
+        attach_mappings = function(_, map)
+            map("i", "<c-d>", delete_harpoon_mark)
+            map("n", "<c-d>", delete_harpoon_mark)
 
-                map("i", "<c-p>", move_mark_up)
-                map("n", "<c-p>", move_mark_up)
+            map("i", "<c-p>", move_mark_up)
+            map("n", "<c-p>", move_mark_up)
 
-                map("i", "<c-n>", move_mark_down)
-                map("n", "<c-n>", move_mark_down)
-                return true
-            end,
-        })
-        :find()
+            map("i", "<c-n>", move_mark_down)
+            map("n", "<c-n>", move_mark_down)
+            return true
+        end,
+    }):find()
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new tabline/autocmd behavior and buffer/keymap handling, which can impact Neovim UI state and user workflows if edge cases (paths, highlights, buffer cleanup) are wrong.
> 
> **Overview**
> Adds an optional Harpoon-driven tabline (`global_settings.tabline`) with configurable prefix/suffix and automatic highlight linking on `ColorScheme`, and forces redraws when marks change.
> 
> Improves the Harpoon quick menu UX by highlighting the current file entry, adding `harpoon`-buffer mappings to open selections in vsplit/split/tab, and tightening navigation (`vim.fs.normalize`, `nvim_win_set_cursor`) while cleaning up empty unnamed buffers after jumping.
> 
> Also updates branch detection to use Fugitive’s `FugitiveHead()` when available, tweaks the Telescope marks picker to preserve original mark indices for move/delete operations, and adds GitHub issue templates plus README messaging to direct users toward the `harpoon2` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc17e3e42ea3c46b33c0bbad6a880792692a1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->